### PR TITLE
fix: add characterData to MutationObserver for live toggle support

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -150,8 +150,9 @@ if (window.cloakScriptInjected !== true) {
                     getAllNodesAndApplyFilter(true);
                     window.cloakObserver && window.cloakObserver.disconnect();
                     window.cloakObserver && window.cloakObserver.observe(document.body, {
-                        childList: true, // Watch for added/removed elements
-                        subtree: true   // Watch the entire subtree of the document
+                        childList: true,    // Watch for added/removed elements
+                        subtree: true,      // Watch the entire subtree of the document
+                        characterData: true // Watch for text content changes (SPA updates)
                     });
                 } else {
                     getAllNodesAndApplyFilter(false);
@@ -164,8 +165,12 @@ if (window.cloakScriptInjected !== true) {
             // MutationObserver to watch for changes in the DOM
             if (!window.cloakObserver) {
                 window.cloakObserver = new MutationObserver((mutationList) => {
-                    // Go through the mutations and apply the filter on the added nodes
+                    // Go through the mutations and apply the filter on the added/changed nodes
                     for (const mutation of mutationList) {
+                        if (mutation.type === 'characterData') {
+                            // Text content changed in-place (common in SPAs like Azure Portal)
+                            applyFilterOnNode(mutation.target, true);
+                        }
                         mutation.addedNodes.forEach((node) => {
                             applyFilterOnNode(node, true /* If observer is running we are in cloak mode */);
                         });


### PR DESCRIPTION
## Problem
The MutationObserver only watched for \childList\ changes, missing in-place text content updates that are common in SPAs like the Azure Portal. This meant that toggling cloaking patterns while the portal was already open wouldn't catch dynamically updated text nodes.

## Fix
- Added \characterData: true\ to the \MutationObserver.observe()\ config
- Added handling for \characterData\ mutation type in the observer callback to re-apply filters on changed text nodes

## Impact
Toggling cloaking on/off while the Azure Portal (or any supported SPA) is open now properly re-crawls text that was updated in-place without DOM addition/removal.

Addresses the live toggle issue noted in #60.