### PR TITLE
perf: debounce toggle re-crawl to prevent jank on rapid changes

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -186,7 +186,10 @@ if (window.cloakScriptInjected !== true) {
                         window.toggleStates[key] = changes[key].newValue !== undefined ? changes[key].newValue : window.toggleStates[key];
                     }
                 }
-                toggleCloak();
+                // Debounce the re-crawl so rapid toggling (e.g. "Toggle All") doesn't
+                // trigger multiple expensive full-DOM walks back-to-back
+                clearTimeout(window.cloakToggleDebounce);
+                window.cloakToggleDebounce = setTimeout(toggleCloak, 100);
             });
 
             chrome.storage.sync.get().then((currentState) => {


### PR DESCRIPTION
## Problem
Every toggle state change triggers a full DOM walk via \	oggleCloak()\. When multiple toggles change in quick succession (e.g. with a 'Toggle All' feature like in #60), this causes unnecessary repeated re-crawls that can cause visible jank on large pages.

## Fix
Added a 100ms debounce on the \chrome.storage.onChanged\ handler so rapid toggle changes coalesce into a single DOM re-crawl.

## Impact
Smoother UX when toggling multiple patterns on/off quickly. Especially relevant alongside #60's 'Toggle All' feature.