### PR TITLE
feat: add page-aware masking for storage key flows

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -5,10 +5,12 @@ if (window.cloakScriptInjected !== true) {
         const src = chrome.runtime.getURL("./common.js");
         import(src).then((commonModule) => {
             const cloakablePatterns = commonModule.cloakablePatterns;
+            const matchesPageRuleLabel = commonModule.matchesPageRuleLabel;
             const pageSpecificRules = commonModule.pageSpecificRules || [];
             const isPageRuleActive = commonModule.isPageRuleActive;
             const normalizePageRuleText = commonModule.normalizePageRuleText;
             const blurFilter = "blur(5px)";
+            const maskText = "*****";
             const resetBlur = "none";
 
             window.regexPatternsArray;
@@ -17,7 +19,6 @@ if (window.cloakScriptInjected !== true) {
             function tryApplyFilterOnElementTitle(element, shouldCloak, force = false) {
                 const titleAttribute = "title";
                 const maskTitleAttribute = "maskTitle";
-                const maskText = "*****";
 
 
                 const title = element.hasAttribute(titleAttribute) ? element.getAttribute(titleAttribute) : "";
@@ -28,7 +29,9 @@ if (window.cloakScriptInjected !== true) {
                 ) {
                     if (shouldCloak) {
                         element.setAttribute(titleAttribute, maskText);
-                        element.setAttribute(maskTitleAttribute, title);
+                        if (!maskTitle) {
+                            element.setAttribute(maskTitleAttribute, title);
+                        }
                     } else {
                         element.setAttribute(titleAttribute, maskTitle);
                         element.removeAttribute(maskTitleAttribute);
@@ -124,13 +127,13 @@ if (window.cloakScriptInjected !== true) {
             }
 
             function elementMatchesPageRuleContext(element, rule) {
-                const labels = (rule.contextLabels || []).map((label) => normalizePageRuleText(label));
+                const labels = rule.contextLabels || [];
                 if (labels.length === 0) {
                     return false;
                 }
 
                 const contextValues = collectRuleContextText(element);
-                return labels.some((label) => contextValues.some((contextValue) => contextValue.includes(label)));
+                return labels.some((label) => contextValues.some((contextValue) => matchesPageRuleLabel(label, contextValue)));
             }
 
             function applyPageRuleMaskToElement(element, shouldCloak, ruleId) {
@@ -151,8 +154,15 @@ if (window.cloakScriptInjected !== true) {
                 }
 
                 element.removeAttribute(ruleMaskAttribute);
-                element.style.filter = matchPatterns(getElementMaskValue(element)) ? blurFilter : resetBlur;
-                tryApplyFilterOnElementTitle(element, false, true);
+                const shouldKeepMaskedByPattern = matchPatterns(getElementMaskValue(element));
+                const originalTitle = element.getAttribute("maskTitle") || "";
+
+                element.style.filter = shouldKeepMaskedByPattern ? blurFilter : resetBlur;
+                if (originalTitle && matchPatterns(originalTitle)) {
+                    element.setAttribute("title", maskText);
+                } else {
+                    tryApplyFilterOnElementTitle(element, false, true);
+                }
             }
 
             function updatePageRuleMatches(rule, matchedElements, shouldCloak) {

--- a/cloak.js
+++ b/cloak.js
@@ -5,13 +5,16 @@ if (window.cloakScriptInjected !== true) {
         const src = chrome.runtime.getURL("./common.js");
         import(src).then((commonModule) => {
             const cloakablePatterns = commonModule.cloakablePatterns;
+            const pageSpecificRules = commonModule.pageSpecificRules || [];
+            const isPageRuleActive = commonModule.isPageRuleActive;
+            const normalizePageRuleText = commonModule.normalizePageRuleText;
             const blurFilter = "blur(5px)";
             const resetBlur = "none";
 
             window.regexPatternsArray;
             window.toggleStates;
 
-            function tryApplyFilterOnElementTitle(element, shouldCloak) {
+            function tryApplyFilterOnElementTitle(element, shouldCloak, force = false) {
                 const titleAttribute = "title";
                 const maskTitleAttribute = "maskTitle";
                 const maskText = "*****";
@@ -20,8 +23,8 @@ if (window.cloakScriptInjected !== true) {
                 const title = element.hasAttribute(titleAttribute) ? element.getAttribute(titleAttribute) : "";
                 const maskTitle = element.hasAttribute(maskTitleAttribute) ? element.getAttribute(maskTitleAttribute) : "";
                 if (
-                    (shouldCloak && title && matchPatterns(title)) ||
-                    (!shouldCloak && maskTitle && matchPatterns(maskTitle))
+                    (shouldCloak && title && (force || matchPatterns(title))) ||
+                    (!shouldCloak && maskTitle && (force || matchPatterns(maskTitle)))
                 ) {
                     if (shouldCloak) {
                         element.setAttribute(titleAttribute, maskText);
@@ -52,6 +55,197 @@ if (window.cloakScriptInjected !== true) {
                 }
 
                 return null;
+            }
+
+            function getPageRuleMaskAttribute(ruleId) {
+                return `data-cloudcloak-page-rule-${ruleId}`;
+            }
+
+            function getActivePageRules() {
+                return pageSpecificRules.filter((rule) => isPageRuleActive(rule, window.location.href, window.toggleStates));
+            }
+
+            function getElementMaskValue(element) {
+                if (!element) {
+                    return "";
+                }
+
+                return (element.value || element.textContent || element.getAttribute("title") || "").trim();
+            }
+
+            function collectRuleContextText(element) {
+                const contextValues = [];
+                const addContextValue = (value) => {
+                    const normalizedValue = normalizePageRuleText(value);
+                    if (normalizedValue) {
+                        contextValues.push(normalizedValue);
+                    }
+                };
+
+                if (!element) {
+                    return contextValues;
+                }
+
+                ["aria-label", "placeholder", "name", "id", "title"].forEach((attributeName) => {
+                    addContextValue(element.getAttribute(attributeName));
+                });
+
+                const labelledBy = (element.getAttribute("aria-labelledby") || "")
+                    .split(/\s+/)
+                    .map((id) => id.trim())
+                    .filter(Boolean);
+                labelledBy.forEach((labelId) => {
+                    addContextValue(document.getElementById(labelId)?.textContent);
+                });
+
+                if (element.labels) {
+                    Array.from(element.labels).forEach((label) => addContextValue(label.textContent));
+                }
+
+                const contextContainer = element.closest("[class*='fxc-gc'], [class*='form'], [class*='row'], [role='row'], [role='group']") || element.parentElement;
+                if (contextContainer) {
+                    addContextValue(contextContainer.getAttribute?.("aria-label"));
+
+                    const directLabelCandidate = Array.from(contextContainer.children || []).find((child) => {
+                        if (child === element || child.contains(element)) {
+                            return false;
+                        }
+
+                        return child.matches("label, [role='label'], [class*='label'], [class*='header'], th, dt");
+                    });
+                    addContextValue(directLabelCandidate?.textContent);
+
+                    addContextValue(element.previousElementSibling?.textContent);
+                    addContextValue(contextContainer.previousElementSibling?.textContent);
+                    addContextValue(contextContainer.parentElement?.previousElementSibling?.textContent);
+                }
+
+                return contextValues;
+            }
+
+            function elementMatchesPageRuleContext(element, rule) {
+                const labels = (rule.contextLabels || []).map((label) => normalizePageRuleText(label));
+                if (labels.length === 0) {
+                    return false;
+                }
+
+                const contextValues = collectRuleContextText(element);
+                return labels.some((label) => contextValues.some((contextValue) => contextValue.includes(label)));
+            }
+
+            function applyPageRuleMaskToElement(element, shouldCloak, ruleId) {
+                if (!element) {
+                    return;
+                }
+
+                const ruleMaskAttribute = getPageRuleMaskAttribute(ruleId);
+                if (shouldCloak) {
+                    element.style.filter = blurFilter;
+                    element.setAttribute(ruleMaskAttribute, "true");
+                    tryApplyFilterOnElementTitle(element, true, true);
+                    return;
+                }
+
+                if (!element.hasAttribute(ruleMaskAttribute)) {
+                    return;
+                }
+
+                element.removeAttribute(ruleMaskAttribute);
+                element.style.filter = matchPatterns(getElementMaskValue(element)) ? blurFilter : resetBlur;
+                tryApplyFilterOnElementTitle(element, false, true);
+            }
+
+            function updatePageRuleMatches(rule, matchedElements, shouldCloak) {
+                const maskedElements = document.querySelectorAll(`[${getPageRuleMaskAttribute(rule.id)}]`);
+                const matchedElementSet = new Set(matchedElements);
+
+                maskedElements.forEach((element) => {
+                    if (!shouldCloak || !matchedElementSet.has(element)) {
+                        applyPageRuleMaskToElement(element, false, rule.id);
+                    }
+                });
+
+                if (!shouldCloak) {
+                    return;
+                }
+
+                matchedElements.forEach((element) => {
+                    applyPageRuleMaskToElement(element, true, rule.id);
+                });
+            }
+
+            function runAzureStorageAccessKeyRule(rule, shouldCloak) {
+                const candidateSelectors = (rule.valueSelectors || []).join(", ");
+                const matchedElements = [];
+                if (candidateSelectors) {
+                    document.querySelectorAll(candidateSelectors).forEach((element) => {
+                        if (!getElementMaskValue(element)) {
+                            return;
+                        }
+
+                        if (elementMatchesPageRuleContext(element, rule)) {
+                            matchedElements.push(element);
+                        }
+                    });
+                }
+
+                updatePageRuleMatches(rule, matchedElements, shouldCloak);
+            }
+
+            function runPageSpecificRule(rule, shouldCloak) {
+                if (rule.id === "azure-storage-access-keys") {
+                    runAzureStorageAccessKeyRule(rule, shouldCloak);
+                } else {
+                    updatePageRuleMatches(rule, [], false);
+                }
+            }
+
+            function runPageSpecificRules(applyFilter) {
+                const activePageRules = new Set(getActivePageRules().map((rule) => rule.id));
+
+                pageSpecificRules.forEach((rule) => {
+                    runPageSpecificRule(rule, applyFilter && activePageRules.has(rule.id));
+                });
+            }
+
+            function schedulePageSpecificRuleRescan() {
+                const activePageRules = getActivePageRules();
+                if (activePageRules.length === 0) {
+                    return;
+                }
+
+                window.pageRuleRescanTimeouts = window.pageRuleRescanTimeouts || [];
+                window.pageRuleRescanTimeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+                window.pageRuleRescanTimeouts = [];
+
+                const rescanDelays = [...new Set(activePageRules.flatMap((rule) => rule.interactionRescanDelays || [0]))];
+                rescanDelays.forEach((delay) => {
+                    window.pageRuleRescanTimeouts.push(setTimeout(() => {
+                        runPageSpecificRules(true);
+                    }, delay));
+                });
+            }
+
+            function ensurePageRuleInteractionHandlers() {
+                if (window.pageRuleInteractionHandlersRegistered) {
+                    return;
+                }
+
+                const scheduleTrustedRescan = (event) => {
+                    if (!event.isTrusted) {
+                        return;
+                    }
+
+                    if (event.type === "keydown" && event.key !== "Enter" && event.key !== " ") {
+                        return;
+                    }
+
+                    schedulePageSpecificRuleRescan();
+                };
+
+                document.addEventListener("click", scheduleTrustedRescan, true);
+                document.addEventListener("keydown", scheduleTrustedRescan, true);
+                window.pageRuleInteractionHandlersRegistered = true;
             }
 
             function specialHandlingForAzurePortalEssentialsValues(applyFilter) {
@@ -262,10 +456,12 @@ if (window.cloakScriptInjected !== true) {
 
                 specialHandlingForPasswordFieldsAndTablesWithSecrets(applyFilter);
                 specialHandlingForAzurePortalEssentialsValues(!!window.toggleStates?.subscriptioninfo && applyFilter);
+                runPageSpecificRules(applyFilter);
             }
             function toggleCloak() {
                 // Update the regex patterns
                 updateRegexPatterns();
+                ensurePageRuleInteractionHandlers();
 
                 if (window.regexPatternsArray?.length > 0 || window.toggleStates?.secrets || window.toggleStates?.subscriptioninfo) {
                     getAllNodesAndApplyFilter(true);
@@ -304,6 +500,7 @@ if (window.cloakScriptInjected !== true) {
                     window.secretHandlingTimeout = setTimeout(() => {
                         specialHandlingForPasswordFieldsAndTablesWithSecrets(true /* If observer is running we are in cloak mode */);
                         specialHandlingForAzurePortalEssentialsValues(!!window.toggleStates?.subscriptioninfo && true /* If observer is running we are in cloak mode */);
+                        runPageSpecificRules(true /* If observer is running we are in cloak mode */);
                     }, 50);
                 });
             }

--- a/cloak.js
+++ b/cloak.js
@@ -219,7 +219,7 @@ if (window.cloakScriptInjected !== true) {
                 });
             }
 
-            function runAzureStorageAccessKeyRule(rule, shouldCloak) {
+            function runContextAwarePageRule(rule, shouldCloak) {
                 const candidateSelectors = (rule.valueSelectors || []).join(", ");
                 const matchedElements = [];
                 if (candidateSelectors) {
@@ -243,8 +243,8 @@ if (window.cloakScriptInjected !== true) {
             }
 
             function runPageSpecificRule(rule, shouldCloak) {
-                if (rule.id === "azure-storage-access-keys") {
-                    runAzureStorageAccessKeyRule(rule, shouldCloak);
+                if (rule.valueSelectors?.length) {
+                    runContextAwarePageRule(rule, shouldCloak);
                 } else {
                     updatePageRuleMatches(rule, [], false);
                 }

--- a/cloak.js
+++ b/cloak.js
@@ -109,14 +109,13 @@ if (window.cloakScriptInjected !== true) {
                 if (contextContainer) {
                     addContextValue(contextContainer.getAttribute?.("aria-label"));
 
-                    const directLabelCandidate = Array.from(contextContainer.children || []).find((child) => {
-                        if (child === element || child.contains(element)) {
-                            return false;
+                    contextContainer.querySelectorAll("label, [role='label'], [class*='label'], [class*='header'], th, dt, legend").forEach((candidate) => {
+                        if (candidate === element || candidate.contains(element)) {
+                            return;
                         }
 
-                        return child.matches("label, [role='label'], [class*='label'], [class*='header'], th, dt");
+                        addContextValue(candidate.textContent);
                     });
-                    addContextValue(directLabelCandidate?.textContent);
 
                     addContextValue(element.previousElementSibling?.textContent);
                     addContextValue(contextContainer.previousElementSibling?.textContent);
@@ -150,19 +149,23 @@ if (window.cloakScriptInjected !== true) {
                     }
                 };
 
-                const contextContainer = element.closest("[class*='fxc-gc'], [class*='form'], [class*='row'], [role='row'], [role='group']") || element.parentElement;
-                if (!contextContainer) {
-                    return false;
+                const contextContainers = [];
+                let currentContainer = element.closest("[class*='fxc-gc'], [class*='form'], [class*='row'], [role='row'], [role='group']") || element.parentElement;
+                for (let depth = 0; currentContainer && depth < (rule.actionSearchDepth || 1); depth++) {
+                    contextContainers.push(currentContainer);
+                    currentContainer = currentContainer.parentElement;
                 }
 
-                contextContainer.querySelectorAll("button, [role='button'], [title], [aria-label]").forEach((candidate) => {
-                    if (candidate === element || candidate.contains(element)) {
-                        return;
-                    }
+                contextContainers.forEach((contextContainer) => {
+                    contextContainer.querySelectorAll("button, [role='button'], [title], [aria-label]").forEach((candidate) => {
+                        if (candidate === element || candidate.contains(element)) {
+                            return;
+                        }
 
-                    addActionText(candidate.textContent);
-                    addActionText(candidate.getAttribute?.("title"));
-                    addActionText(candidate.getAttribute?.("aria-label"));
+                        addActionText(candidate.textContent);
+                        addActionText(candidate.getAttribute?.("title"));
+                        addActionText(candidate.getAttribute?.("aria-label"));
+                    });
                 });
 
                 return actionLabels.some((label) => actionTexts.some((actionText) => matchesPageRuleLabel(label, actionText)));

--- a/cloak.js
+++ b/cloak.js
@@ -136,6 +136,38 @@ if (window.cloakScriptInjected !== true) {
                 return labels.some((label) => contextValues.some((contextValue) => matchesPageRuleLabel(label, contextValue)));
             }
 
+            function elementHasNearbyRuleActions(element, rule) {
+                const actionLabels = rule.nearbyActionLabels || [];
+                if (actionLabels.length === 0) {
+                    return false;
+                }
+
+                const actionTexts = [];
+                const addActionText = (value) => {
+                    const normalizedValue = normalizePageRuleText(value);
+                    if (normalizedValue) {
+                        actionTexts.push(normalizedValue);
+                    }
+                };
+
+                const contextContainer = element.closest("[class*='fxc-gc'], [class*='form'], [class*='row'], [role='row'], [role='group']") || element.parentElement;
+                if (!contextContainer) {
+                    return false;
+                }
+
+                contextContainer.querySelectorAll("button, [role='button'], [title], [aria-label]").forEach((candidate) => {
+                    if (candidate === element || candidate.contains(element)) {
+                        return;
+                    }
+
+                    addActionText(candidate.textContent);
+                    addActionText(candidate.getAttribute?.("title"));
+                    addActionText(candidate.getAttribute?.("aria-label"));
+                });
+
+                return actionLabels.some((label) => actionTexts.some((actionText) => matchesPageRuleLabel(label, actionText)));
+            }
+
             function applyPageRuleMaskToElement(element, shouldCloak, ruleId) {
                 if (!element) {
                     return;
@@ -189,11 +221,16 @@ if (window.cloakScriptInjected !== true) {
                 const matchedElements = [];
                 if (candidateSelectors) {
                     document.querySelectorAll(candidateSelectors).forEach((element) => {
-                        if (!getElementMaskValue(element)) {
+                        const elementValue = getElementMaskValue(element);
+                        if (!elementValue) {
                             return;
                         }
 
-                        if (elementMatchesPageRuleContext(element, rule)) {
+                        const meetsMinimumValueLength = elementValue.length >= (rule.minimumValueLength || 1);
+                        const matchesRuleContext = elementMatchesPageRuleContext(element, rule);
+                        const hasNearbyActions = meetsMinimumValueLength && elementHasNearbyRuleActions(element, rule);
+
+                        if (matchesRuleContext || hasNearbyActions) {
                             matchedElements.push(element);
                         }
                     });

--- a/common.js
+++ b/common.js
@@ -61,6 +61,57 @@ export function isSupportedUrl(url) {
             supportedDomainMatcher.hostnameRegex.test(currentUrl.hostname);
     });
 }
+
+export function normalizePageRuleText(value) {
+    return (value || "")
+        .replace(/\s+/g, " ")
+        .trim()
+        .toLowerCase();
+}
+
+export const pageSpecificRules = [
+    {
+        id: "azure-storage-access-keys",
+        toggleId: "secrets",
+        urlRegexes: [
+            /storageaccounts/i,
+            /(access[-\s]?keys|(?:\/|=)keys(?:[/?#]|$)|sharedaccesssignature|shared access signature|\bsas\b)/i
+        ],
+        contextLabels: [
+            "key",
+            "key1",
+            "key2",
+            "connection string",
+            "shared access signature",
+            "sas",
+            "signature",
+            "secret"
+        ],
+        valueSelectors: [
+            "input",
+            "textarea",
+            "[role='textbox']"
+        ],
+        interactionRescanDelays: [0, 75, 250]
+    }
+];
+
+export function matchesPageRuleUrl(rule, url) {
+    if (!rule || !url) {
+        return false;
+    }
+
+    return (rule.urlRegexes || []).every((regex) => regex.test(url));
+}
+
+export function isPageRuleActive(rule, url, toggleStates = {}) {
+    if (!rule || !rule.toggleId || !toggleStates[rule.toggleId]) {
+        return false;
+    }
+
+    return matchesPageRuleUrl(rule, url);
+}
+
 const ipAddressRegexes = [
     /(?<![0-9A-Za-z.])(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}(?![0-9A-Za-z]|\.\d)/, // IPv4
     /(?<![0-9A-Za-z:])(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}(?![0-9A-Za-z:]|\.\d)/, // IPv6 expanded

--- a/common.js
+++ b/common.js
@@ -69,6 +69,21 @@ export function normalizePageRuleText(value) {
         .toLowerCase();
 }
 
+export function matchesPageRuleLabel(label, contextValue) {
+    const normalizedLabel = normalizePageRuleText(label);
+    const normalizedContextValue = normalizePageRuleText(contextValue);
+    if (!normalizedLabel || !normalizedContextValue) {
+        return false;
+    }
+
+    const labelPattern = normalizedLabel
+        .split(" ")
+        .map(escapeRegex)
+        .join("\\s+");
+
+    return new RegExp(`(^|[^a-z0-9])${labelPattern}($|[^a-z0-9])`, "i").test(normalizedContextValue);
+}
+
 export const pageSpecificRules = [
     {
         id: "azure-storage-access-keys",
@@ -81,6 +96,8 @@ export const pageSpecificRules = [
             "key",
             "key1",
             "key2",
+            "key 1",
+            "key 2",
             "connection string",
             "shared access signature",
             "sas",

--- a/common.js
+++ b/common.js
@@ -113,6 +113,41 @@ export const pageSpecificRules = [
         nearbyActionLabels: [
             "show",
             "hide",
+            "copy",
+            "generate",
+            "generate sas",
+            "generate sas and connection string"
+        ],
+        minimumValueLength: 16,
+        actionSearchDepth: 4,
+        interactionRescanDelays: [0, 75, 250, 500, 1000]
+    },
+    {
+        id: "azure-ai-studio-keys",
+        toggleId: "secrets",
+        urlRegexes: [
+            /ai\.azure\.com/i,
+            /resource/i
+        ],
+        contextLabels: [
+            "key",
+            "key1",
+            "key2",
+            "key 1",
+            "key 2",
+            "api key",
+            "access key",
+            "secret"
+        ],
+        valueSelectors: [
+            "input",
+            "textarea",
+            "[role='textbox']",
+            "[class*='value']"
+        ],
+        nearbyActionLabels: [
+            "show",
+            "hide",
             "copy"
         ],
         minimumValueLength: 16,

--- a/common.js
+++ b/common.js
@@ -116,7 +116,8 @@ export const pageSpecificRules = [
             "copy"
         ],
         minimumValueLength: 16,
-        interactionRescanDelays: [0, 75, 250]
+        actionSearchDepth: 4,
+        interactionRescanDelays: [0, 75, 250, 500, 1000]
     }
 ];
 

--- a/common.js
+++ b/common.js
@@ -107,8 +107,15 @@ export const pageSpecificRules = [
         valueSelectors: [
             "input",
             "textarea",
-            "[role='textbox']"
+            "[role='textbox']",
+            "[class*='value']"
         ],
+        nearbyActionLabels: [
+            "show",
+            "hide",
+            "copy"
+        ],
+        minimumValueLength: 16,
         interactionRescanDelays: [0, 75, 250]
     }
 ];

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -10,6 +10,7 @@ import {
 } from '../common.js';
 
 const azureStorageAccessKeyRule = pageSpecificRules.find((rule) => rule.id === 'azure-storage-access-keys');
+const azureAiStudioKeysRule = pageSpecificRules.find((rule) => rule.id === 'azure-ai-studio-keys');
 
 test('normalizes page rule text for label matching', () => {
     assert.equal(normalizePageRuleText('  Shared   Access   Signature  '), 'shared access signature');
@@ -38,6 +39,24 @@ test('matches Azure Storage access key routes', () => {
         matchesPageRuleUrl(
             azureStorageAccessKeyRule,
             'https://portal.azure.com/#resource/subscriptions/test/resourceGroups/demo/providers/Microsoft.Storage/storageAccounts/demo/sharedaccesssignature'
+        ),
+        true
+    );
+});
+
+test('matches Azure AI Studio key routes', () => {
+    assert.equal(
+        matchesPageRuleUrl(
+            azureAiStudioKeysRule,
+            'https://ai.azure.com/resource?tid=72f988bf-86f1-41af-91ab-2d7cd011db47'
+        ),
+        true
+    );
+
+    assert.equal(
+        matchesPageRuleUrl(
+            azureAiStudioKeysRule,
+            'https://ai.azure.com/resource/subscriptions/test/resourceGroups/demo'
         ),
         true
     );
@@ -72,5 +91,10 @@ test('activates page rules only when the linked toggle is enabled', () => {
     assert.equal(
         isPageRuleActive(azureStorageAccessKeyRule, targetUrl, { secrets: false }),
         false
+    );
+
+    assert.equal(
+        isPageRuleActive(azureAiStudioKeysRule, 'https://ai.azure.com/resource?tid=test', { secrets: true }),
+        true
     );
 });

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
     isPageRuleActive,
+    matchesPageRuleLabel,
     matchesPageRuleUrl,
     normalizePageRuleText,
     pageSpecificRules
@@ -14,6 +15,14 @@ test('normalizes page rule text for label matching', () => {
     assert.equal(normalizePageRuleText('  Shared   Access   Signature  '), 'shared access signature');
     assert.equal(normalizePageRuleText('Key1'), 'key1');
     assert.equal(normalizePageRuleText(''), '');
+});
+
+test('matches page rule labels on word boundaries instead of substrings', () => {
+    assert.equal(matchesPageRuleLabel('key', 'Storage account key'), true);
+    assert.equal(matchesPageRuleLabel('connection string', 'Primary connection string'), true);
+    assert.equal(matchesPageRuleLabel('key', 'Search keywords'), false);
+    assert.equal(matchesPageRuleLabel('key', 'Keyboard shortcut'), false);
+    assert.equal(matchesPageRuleLabel('key 1', 'Key 1'), true);
 });
 
 test('matches Azure Storage access key routes', () => {

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    isPageRuleActive,
+    matchesPageRuleUrl,
+    normalizePageRuleText,
+    pageSpecificRules
+} from '../common.js';
+
+const azureStorageAccessKeyRule = pageSpecificRules.find((rule) => rule.id === 'azure-storage-access-keys');
+
+test('normalizes page rule text for label matching', () => {
+    assert.equal(normalizePageRuleText('  Shared   Access   Signature  '), 'shared access signature');
+    assert.equal(normalizePageRuleText('Key1'), 'key1');
+    assert.equal(normalizePageRuleText(''), '');
+});
+
+test('matches Azure Storage access key routes', () => {
+    assert.equal(
+        matchesPageRuleUrl(
+            azureStorageAccessKeyRule,
+            'https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Storage%2FstorageAccounts~2FstorageAccounts/menuId/keys'
+        ),
+        true
+    );
+
+    assert.equal(
+        matchesPageRuleUrl(
+            azureStorageAccessKeyRule,
+            'https://portal.azure.com/#resource/subscriptions/test/resourceGroups/demo/providers/Microsoft.Storage/storageAccounts/demo/sharedaccesssignature'
+        ),
+        true
+    );
+});
+
+test('does not match unrelated Azure Storage routes', () => {
+    assert.equal(
+        matchesPageRuleUrl(
+            azureStorageAccessKeyRule,
+            'https://portal.azure.com/#resource/subscriptions/test/resourceGroups/demo/providers/Microsoft.Storage/storageAccounts/demo/overview'
+        ),
+        false
+    );
+
+    assert.equal(
+        matchesPageRuleUrl(
+            azureStorageAccessKeyRule,
+            'https://portal.azure.com/#view/Microsoft_Azure_AI/OpenAI'
+        ),
+        false
+    );
+});
+
+test('activates page rules only when the linked toggle is enabled', () => {
+    const targetUrl = 'https://portal.azure.com/#resource/subscriptions/test/resourceGroups/demo/providers/Microsoft.Storage/storageAccounts/demo/keys';
+
+    assert.equal(
+        isPageRuleActive(azureStorageAccessKeyRule, targetUrl, { secrets: true }),
+        true
+    );
+
+    assert.equal(
+        isPageRuleActive(azureStorageAccessKeyRule, targetUrl, { secrets: false }),
+        false
+    );
+});


### PR DESCRIPTION
## Summary
- add page-aware masking for Azure Storage access key and SAS-style pages
- reuse the existing `secrets` toggle and run page-aware masking after regex scans, mutation rescans, and trusted interactions
- tighten title-state handling and label matching safeguards to avoid false positives and preserve masked tooltip state
- extend the same page-rule pattern to Azure AI Studio key reveal flows and broader Azure Storage SAS/generate flows
- add focused tests for page-rule URL activation and label-matching helpers

## Validation
- `node --check background.js`
- `node --check cloak.js`
- `node --check common.js`
- `node --check popup.js`
- `node --test tests/ipaddresses.test.mjs tests/pageSpecificRules.test.mjs`
- manual validation completed for Azure Storage `Show` key reveal flows

## Notes
- Includes the follow-up work from merged stacked PR #74 (`+62 / -3`, 3 files, 1 commit) on top of the original PR branch.

Closes #20.
Closes #42.
Refs #45.