### PR TITLE
feat: extend page-rule masking to AI Studio and SAS flows

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -219,7 +219,7 @@ if (window.cloakScriptInjected !== true) {
                 });
             }
 
-            function runAzureStorageAccessKeyRule(rule, shouldCloak) {
+            function runContextAwarePageRule(rule, shouldCloak) {
                 const candidateSelectors = (rule.valueSelectors || []).join(", ");
                 const matchedElements = [];
                 if (candidateSelectors) {
@@ -243,8 +243,8 @@ if (window.cloakScriptInjected !== true) {
             }
 
             function runPageSpecificRule(rule, shouldCloak) {
-                if (rule.id === "azure-storage-access-keys") {
-                    runAzureStorageAccessKeyRule(rule, shouldCloak);
+                if (rule.valueSelectors?.length) {
+                    runContextAwarePageRule(rule, shouldCloak);
                 } else {
                     updatePageRuleMatches(rule, [], false);
                 }

--- a/common.js
+++ b/common.js
@@ -113,6 +113,41 @@ export const pageSpecificRules = [
         nearbyActionLabels: [
             "show",
             "hide",
+            "copy",
+            "generate",
+            "generate sas",
+            "generate sas and connection string"
+        ],
+        minimumValueLength: 16,
+        actionSearchDepth: 4,
+        interactionRescanDelays: [0, 75, 250, 500, 1000]
+    },
+    {
+        id: "azure-ai-studio-keys",
+        toggleId: "secrets",
+        urlRegexes: [
+            /ai\.azure\.com/i,
+            /resource/i
+        ],
+        contextLabels: [
+            "key",
+            "key1",
+            "key2",
+            "key 1",
+            "key 2",
+            "api key",
+            "access key",
+            "secret"
+        ],
+        valueSelectors: [
+            "input",
+            "textarea",
+            "[role='textbox']",
+            "[class*='value']"
+        ],
+        nearbyActionLabels: [
+            "show",
+            "hide",
             "copy"
         ],
         minimumValueLength: 16,

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -10,6 +10,7 @@ import {
 } from '../common.js';
 
 const azureStorageAccessKeyRule = pageSpecificRules.find((rule) => rule.id === 'azure-storage-access-keys');
+const azureAiStudioKeysRule = pageSpecificRules.find((rule) => rule.id === 'azure-ai-studio-keys');
 
 test('normalizes page rule text for label matching', () => {
     assert.equal(normalizePageRuleText('  Shared   Access   Signature  '), 'shared access signature');
@@ -38,6 +39,24 @@ test('matches Azure Storage access key routes', () => {
         matchesPageRuleUrl(
             azureStorageAccessKeyRule,
             'https://portal.azure.com/#resource/subscriptions/test/resourceGroups/demo/providers/Microsoft.Storage/storageAccounts/demo/sharedaccesssignature'
+        ),
+        true
+    );
+});
+
+test('matches Azure AI Studio key routes', () => {
+    assert.equal(
+        matchesPageRuleUrl(
+            azureAiStudioKeysRule,
+            'https://ai.azure.com/resource?tid=72f988bf-86f1-41af-91ab-2d7cd011db47'
+        ),
+        true
+    );
+
+    assert.equal(
+        matchesPageRuleUrl(
+            azureAiStudioKeysRule,
+            'https://ai.azure.com/resource/subscriptions/test/resourceGroups/demo'
         ),
         true
     );
@@ -72,5 +91,10 @@ test('activates page rules only when the linked toggle is enabled', () => {
     assert.equal(
         isPageRuleActive(azureStorageAccessKeyRule, targetUrl, { secrets: false }),
         false
+    );
+
+    assert.equal(
+        isPageRuleActive(azureAiStudioKeysRule, 'https://ai.azure.com/resource?tid=test', { secrets: true }),
+        true
     );
 });


### PR DESCRIPTION
## Summary
- generalize the context-aware page-rule runner so additional rules can reuse the same matching pattern
- add an Azure AI Studio key reveal rule for issue #42
- extend the Azure Storage rule to better cover SAS generate flows for issue #45

## Validation
- `node --check background.js`
- `node --check cloak.js`
- `node --check common.js`
- `node --check popup.js`
- `node --test tests/ipaddresses.test.mjs tests/pageSpecificRules.test.mjs`

Stacked on top of #73.
Closes #42.
Refs #45.