### PR TITLE
fix: observe dynamic tooltip title changes

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -5,6 +5,7 @@ if (window.cloakScriptInjected !== true) {
         const src = chrome.runtime.getURL("./common.js");
         import(src).then((commonModule) => {
             const cloakablePatterns = commonModule.cloakablePatterns;
+            const cloakObserverOptions = commonModule.cloakObserverOptions;
             const matchesPageRuleLabel = commonModule.matchesPageRuleLabel;
             const pageSpecificRules = commonModule.pageSpecificRules || [];
             const isPageRuleActive = commonModule.isPageRuleActive;
@@ -408,6 +409,8 @@ if (window.cloakScriptInjected !== true) {
                 if (node.nodeType === Node.TEXT_NODE || node.nodeName === "INPUT") {
                     tryMatchAndApplyFilterOnTextNode(node, applyFilter);
                 } else if (node.nodeType === Node.ELEMENT_NODE) {
+                    tryApplyFilterOnElementTitle(node, applyFilter);
+
                     // Handle child nodes
                     for (const child of node.childNodes) {
                         if ((child.nodeType === Node.TEXT_NODE || child.nodeName === "INPUT") && tryMatchAndApplyFilterOnTextNode(child, applyFilter)) {
@@ -516,11 +519,7 @@ if (window.cloakScriptInjected !== true) {
                 if (window.regexPatternsArray?.length > 0 || window.toggleStates?.secrets || window.toggleStates?.subscriptioninfo) {
                     getAllNodesAndApplyFilter(true);
                     window.cloakObserver && window.cloakObserver.disconnect();
-                    window.cloakObserver && window.cloakObserver.observe(document.body, {
-                        childList: true,    // Watch for added/removed elements
-                        subtree: true,      // Watch the entire subtree of the document
-                        characterData: true // Watch for text content changes (SPA updates)
-                    });
+                    window.cloakObserver && window.cloakObserver.observe(document.body, cloakObserverOptions);
                 } else {
                     getAllNodesAndApplyFilter(false);
                     window.cloakObserver && window.cloakObserver.disconnect();
@@ -538,6 +537,9 @@ if (window.cloakScriptInjected !== true) {
                     for (const mutation of mutationList) {
                         if (mutation.type === 'characterData') {
                             // Text content changed in-place (common in SPAs like Azure Portal)
+                            applyFilterOnNode(mutation.target, true);
+                        }
+                        if (mutation.type === 'attributes') {
                             applyFilterOnNode(mutation.target, true);
                         }
                         mutation.addedNodes.forEach((node) => {

--- a/common.js
+++ b/common.js
@@ -62,6 +62,14 @@ export function isSupportedUrl(url) {
     });
 }
 
+export const cloakObserverOptions = {
+    childList: true,
+    subtree: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ["title"]
+};
+
 export function normalizePageRuleText(value) {
     return (value || "")
         .replace(/\s+/g, " ")

--- a/tests/observerConfig.test.mjs
+++ b/tests/observerConfig.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cloakObserverOptions } from '../common.js';
+
+test('observes title attribute mutations for tooltip masking', () => {
+    assert.equal(cloakObserverOptions.attributes, true);
+    assert.deepEqual(cloakObserverOptions.attributeFilter, ['title']);
+    assert.equal(cloakObserverOptions.childList, true);
+    assert.equal(cloakObserverOptions.subtree, true);
+    assert.equal(cloakObserverOptions.characterData, true);
+});


### PR DESCRIPTION
## Summary
- observe title attribute mutations so dynamically added tooltips are reprocessed
- re-run masking on mutated elements so tooltip-only updates on existing nodes are not missed
- add a regression test for the shared observer configuration

Fixes #38