### PR TITLE
fix: narrow extension host permissions

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,19 +23,29 @@ function getCurrentStateFromStorageAndUpdateBadge() {
   });
 }
 
-// Inject the cloak script into the current tab/iframes
-async function injectScripts(tabId, frameIds, allFrames) {
-  allFrames = false;
+// Inject the cloak script into the supported frames of the current tab
+async function injectScripts(tabId, frameIds = [0]) {
+  if (!tabId || !frameIds?.length) {
+    return;
+  }
+
   await chrome.scripting.executeScript({
-    target: { tabId, allFrames, frameIds },
+    target: { tabId, frameIds },
     files: ['cloak.js']
   });
 }
 
+async function getSupportedFrameIds(tabId) {
+  const frameDetails = await chrome.webNavigation.getAllFrames({ tabId });
+  return (frameDetails || [])
+    .filter((frameDetail) => isSupportedUrl(frameDetail.url))
+    .map((frameDetail) => frameDetail.frameId);
+}
+
 // This event is triggered when navigation occurs, which can include loading iframes
 chrome.webNavigation.onCommitted.addListener(async (details) => {
-  if (details.frameId !== 0) { // This is an iframe
-    await injectScripts(details.tabId, [details.frameId], false);
+  if (details.frameId !== 0 && isSupportedUrl(details.url)) { // This is a supported iframe
+    await injectScripts(details.tabId, [details.frameId]);
   }
 }, { url: [{ urlMatches: 'https://*/*' }] });
 
@@ -45,7 +55,8 @@ async function tabsEventHandler() {
       const tabUrl = tabs[0]?.url;
       const tabId = tabs[0]?.id;
       if (isSupportedUrl(tabUrl)) {
-        await injectScripts(tabId, null, true);
+        const supportedFrameIds = await getSupportedFrameIds(tabId);
+        await injectScripts(tabId, supportedFrameIds);
         getCurrentStateFromStorageAndUpdateBadge();
       }
     

--- a/common.js
+++ b/common.js
@@ -23,6 +23,18 @@ export const supportedDomains = [
     'https://*.reactblade.portal.azure.net'
 ];
 
+const exactSupportedHostPermissionPatterns = supportedDomains
+    .filter((supportedDomain) => !supportedDomain.includes('*'))
+    .map((supportedDomain) => `${supportedDomain}/*`);
+
+export const supportedHostPermissionPatterns = [
+    ...exactSupportedHostPermissionPatterns,
+    'https://*.reactblade-ms.portal.azure.net/*',
+    'https://*.reactblade.portal.azure.net/*',
+    // Chrome host match patterns cannot express reactblade-ms*.portal.azure.net or reactblade*.portal.azure.net.
+    'https://*.portal.azure.net/*'
+];
+
 function escapeRegex(value) {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,29 @@
     }
   },
   "web_accessible_resources": [{
-     "matches": ["<all_urls>"],
+     "matches": [
+       "https://portal.azure.com/*",
+       "https://ms.portal.azure.com/*",
+       "https://rc.portal.azure.com/*",
+       "https://preview.portal.azure.com/*",
+       "https://entra.microsoft.com/*",
+       "https://intune.microsoft.com/*",
+       "https://ai.azure.com/*",
+       "https://admin.microsoft.com/*",
+       "https://sip.security.microsoft.com/*",
+       "https://purview.microsoft.com/*",
+       "https://make.powerapps.com/*",
+       "https://make.preview.powerapps.com/*",
+       "https://msazure.visualstudio.com/*",
+       "https://github.com/*",
+       "https://copilotstudio.microsoft.com/*",
+       "https://copilotstudio.preview.microsoft.com/*",
+       "https://reactblade-ms.portal.azure.net/*",
+       "https://reactblade.portal.azure.net/*",
+       "https://*.reactblade-ms.portal.azure.net/*",
+       "https://*.reactblade.portal.azure.net/*",
+       "https://*.portal.azure.net/*"
+     ],
      "resources": ["common.js"]
    }],
   "permissions": [
@@ -33,6 +55,26 @@
     "storage"
   ],
   "host_permissions": [
-    "https://*/"
+    "https://portal.azure.com/*",
+    "https://ms.portal.azure.com/*",
+    "https://rc.portal.azure.com/*",
+    "https://preview.portal.azure.com/*",
+    "https://entra.microsoft.com/*",
+    "https://intune.microsoft.com/*",
+    "https://ai.azure.com/*",
+    "https://admin.microsoft.com/*",
+    "https://sip.security.microsoft.com/*",
+    "https://purview.microsoft.com/*",
+    "https://make.powerapps.com/*",
+    "https://make.preview.powerapps.com/*",
+    "https://msazure.visualstudio.com/*",
+    "https://github.com/*",
+    "https://copilotstudio.microsoft.com/*",
+    "https://copilotstudio.preview.microsoft.com/*",
+    "https://reactblade-ms.portal.azure.net/*",
+    "https://reactblade.portal.azure.net/*",
+    "https://*.reactblade-ms.portal.azure.net/*",
+    "https://*.reactblade.portal.azure.net/*",
+    "https://*.portal.azure.net/*"
   ]
 }

--- a/tests/hostPermissions.test.mjs
+++ b/tests/hostPermissions.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import {
+    supportedDomains,
+    supportedHostPermissionPatterns
+} from '../common.js';
+
+const manifest = JSON.parse(
+    await readFile(new URL('../manifest.json', import.meta.url), 'utf8')
+);
+
+function matchesHostPermission(url, pattern) {
+    const candidateUrl = new URL(url);
+    const [scheme, hostAndPath] = pattern.split('://');
+    const matchHostname = hostAndPath.slice(0, -2);
+
+    if (candidateUrl.protocol !== `${scheme}:`) {
+        return false;
+    }
+
+    const candidateHostname = candidateUrl.hostname;
+    if (!matchHostname.startsWith('*.')) {
+        return candidateHostname === matchHostname;
+    }
+
+    const hostnameSuffix = matchHostname.slice(2);
+    return candidateHostname.endsWith(`.${hostnameSuffix}`);
+}
+
+function getRepresentativeSupportedUrl(supportedDomain) {
+    return supportedDomain
+        .replace('reactblade-ms*', 'reactblade-ms123')
+        .replace('reactblade*', 'reactblade123')
+        .replace('https://*.reactblade-ms.portal.azure.net', 'https://child.reactblade-ms.portal.azure.net')
+        .replace('https://*.reactblade.portal.azure.net', 'https://child.reactblade.portal.azure.net');
+}
+
+test('manifest host permissions stay aligned with supported host permission patterns', () => {
+    assert.deepEqual(manifest.host_permissions, supportedHostPermissionPatterns);
+    assert.deepEqual(manifest.web_accessible_resources[0]?.matches, supportedHostPermissionPatterns);
+});
+
+test('supported host permission patterns cover supported domains', () => {
+    const uncoveredSupportedUrls = supportedDomains
+        .map(getRepresentativeSupportedUrl)
+        .filter((supportedUrl) => !supportedHostPermissionPatterns.some((pattern) => matchesHostPermission(supportedUrl, pattern)));
+
+    assert.deepEqual(uncoveredSupportedUrls, []);
+});


### PR DESCRIPTION
## Summary
- replace the broad host permission with the narrowest practical allowlist for supported portals
- align web accessible resource matches with the same allowlist
- inject only into supported frames so runtime behavior stays consistent with the tighter manifest
- add a regression test that keeps manifest permissions aligned with supported hosts

Fixes #32