### PR TITLE
fix: harden storage reveal flow masking

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -65,6 +65,18 @@ if (window.cloakScriptInjected !== true) {
                 return `data-cloudcloak-page-rule-${ruleId}`;
             }
 
+            function getPageRuleMaskTarget(element, rule) {
+                if (!element) {
+                    return null;
+                }
+
+                if (!rule?.maskClosestSelector) {
+                    return element;
+                }
+
+                return element.closest(rule.maskClosestSelector) || element;
+            }
+
             function getActivePageRules() {
                 return pageSpecificRules.filter((rule) => isPageRuleActive(rule, window.location.href, window.toggleStates));
             }
@@ -223,6 +235,7 @@ if (window.cloakScriptInjected !== true) {
             function runContextAwarePageRule(rule, shouldCloak) {
                 const candidateSelectors = (rule.valueSelectors || []).join(", ");
                 const matchedElements = [];
+                const matchedElementSet = new Set();
                 if (candidateSelectors) {
                     document.querySelectorAll(candidateSelectors).forEach((element) => {
                         const elementValue = getElementMaskValue(element);
@@ -235,7 +248,11 @@ if (window.cloakScriptInjected !== true) {
                         const hasNearbyActions = meetsMinimumValueLength && elementHasNearbyRuleActions(element, rule);
 
                         if (matchesRuleContext || hasNearbyActions) {
-                            matchedElements.push(element);
+                            const maskTarget = getPageRuleMaskTarget(element, rule);
+                            if (maskTarget && !matchedElementSet.has(maskTarget)) {
+                                matchedElementSet.add(maskTarget);
+                                matchedElements.push(maskTarget);
+                            }
                         }
                     });
                 }

--- a/common.js
+++ b/common.js
@@ -128,7 +128,12 @@ export const pageSpecificRules = [
             "input",
             "textarea",
             "[role='textbox']",
-            "[class*='value']"
+            "[class*='value']",
+            "[class*='output']",
+            "[class*='content']",
+            "[class*='text']",
+            "code",
+            "pre"
         ],
         nearbyActionLabels: [
             "show",
@@ -138,6 +143,7 @@ export const pageSpecificRules = [
             "generate sas",
             "generate sas and connection string"
         ],
+        maskClosestSelector: "[class*='fxc-gc'], [class*='form'], [class*='row'], [role='row'], [role='group']",
         minimumValueLength: 16,
         actionSearchDepth: 4,
         interactionRescanDelays: [0, 75, 250, 500, 1000]

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -44,6 +44,13 @@ test('matches Azure Storage access key routes', () => {
     );
 });
 
+test('Azure Storage access key rule targets reveal-flow containers and output-like elements', () => {
+    assert.equal(azureStorageAccessKeyRule.maskClosestSelector.includes("[role='row']"), true);
+    assert.equal(azureStorageAccessKeyRule.valueSelectors.includes("[class*='output']"), true);
+    assert.equal(azureStorageAccessKeyRule.valueSelectors.includes("code"), true);
+    assert.equal(azureStorageAccessKeyRule.valueSelectors.includes("pre"), true);
+});
+
 test('matches Azure AI Studio key routes', () => {
     assert.equal(
         matchesPageRuleUrl(


### PR DESCRIPTION
## Summary
- broaden Azure Storage key/SAS page-rule selectors to cover additional output and rendered text containers
- mask the nearest storage row/group container so reveal-on-click flows stay blurred when Azure swaps DOM children after Show or Generate SAS
- extend page-rule coverage tests for the new reveal-flow targeting behavior

Fixes #45