### PR TITLE
fix: mask AI Studio metadata fields

### DIFF
--- a/common.js
+++ b/common.js
@@ -163,19 +163,31 @@ export const pageSpecificRules = [
             "key 2",
             "api key",
             "access key",
-            "secret"
+            "secret",
+            "created by",
+            "modified by",
+            "endpoint",
+            "endpoint uri",
+            "base url"
         ],
         valueSelectors: [
             "input",
             "textarea",
             "[role='textbox']",
-            "[class*='value']"
+            "[class*='value']",
+            "[class*='output']",
+            "[class*='content']",
+            "[class*='text']",
+            "code",
+            "pre",
+            "a[href]"
         ],
         nearbyActionLabels: [
             "show",
             "hide",
             "copy"
         ],
+        maskClosestSelector: "[class*='form'], [class*='row'], [role='row'], [role='group'], [class*='section']",
         minimumValueLength: 16,
         actionSearchDepth: 4,
         interactionRescanDelays: [0, 75, 250, 500, 1000]

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -69,6 +69,16 @@ test('matches Azure AI Studio key routes', () => {
     );
 });
 
+test('Azure AI Studio rule covers metadata fields and output-like containers', () => {
+    assert.equal(azureAiStudioKeysRule.contextLabels.includes('created by'), true);
+    assert.equal(azureAiStudioKeysRule.contextLabels.includes('modified by'), true);
+    assert.equal(azureAiStudioKeysRule.contextLabels.includes('endpoint uri'), true);
+    assert.equal(azureAiStudioKeysRule.valueSelectors.includes('[class*="output"]'), false);
+    assert.equal(azureAiStudioKeysRule.valueSelectors.includes("[class*='output']"), true);
+    assert.equal(azureAiStudioKeysRule.valueSelectors.includes('a[href]'), true);
+    assert.equal(azureAiStudioKeysRule.maskClosestSelector.includes("[role='row']"), true);
+});
+
 test('does not match unrelated Azure Storage routes', () => {
     assert.equal(
         matchesPageRuleUrl(


### PR DESCRIPTION
## Summary
- extend the Azure AI Studio page rule to cover metadata labels like Created by, Modified by, and Endpoint uri
- broaden AI Studio value targeting to include output/content/text/link containers used by the portal UI
- add regression coverage for the AI Studio rule configuration

Fixes #47