### PR TITLE
fix: reduce dropdown masking flashes

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -311,6 +311,7 @@ if (window.cloakScriptInjected !== true) {
                     schedulePageSpecificRuleRescan();
                 };
 
+                document.addEventListener("mousedown", scheduleTrustedRescan, true);
                 document.addEventListener("click", scheduleTrustedRescan, true);
                 document.addEventListener("keydown", scheduleTrustedRescan, true);
                 window.pageRuleInteractionHandlersRegistered = true;

--- a/common.js
+++ b/common.js
@@ -79,7 +79,7 @@ export const cloakObserverOptions = {
     subtree: true,
     characterData: true,
     attributes: true,
-    attributeFilter: ["title"]
+    attributeFilter: ["title", "class", "style", "hidden", "aria-expanded", "aria-hidden"]
 };
 
 export function normalizePageRuleText(value) {

--- a/tests/observerConfig.test.mjs
+++ b/tests/observerConfig.test.mjs
@@ -3,9 +3,12 @@ import assert from 'node:assert/strict';
 
 import { cloakObserverOptions } from '../common.js';
 
-test('observes title attribute mutations for tooltip masking', () => {
+test('observes title and visibility-related attribute mutations for dynamic masking', () => {
     assert.equal(cloakObserverOptions.attributes, true);
-    assert.deepEqual(cloakObserverOptions.attributeFilter, ['title']);
+    assert.deepEqual(
+        cloakObserverOptions.attributeFilter,
+        ['title', 'class', 'style', 'hidden', 'aria-expanded', 'aria-hidden']
+    );
     assert.equal(cloakObserverOptions.childList, true);
     assert.equal(cloakObserverOptions.subtree, true);
     assert.equal(cloakObserverOptions.characterData, true);


### PR DESCRIPTION
## Summary
- observe visibility-related attribute changes used by dropdown and menu UIs so masking reacts when hidden content becomes visible
- trigger page-rule rescans on mousedown in addition to click and keyboard activation to reduce open-time flashes
- extend observer regression coverage for the new mutation types

Fixes #44