### PR TITLE
fix: broaden sensitive field masking

### DIFF
--- a/cloak.js
+++ b/cloak.js
@@ -481,7 +481,7 @@ if (window.cloakScriptInjected !== true) {
             }
 
             function specialHandlingForPasswordFieldsAndTablesWithSecrets(applyFilter) {
-                const passwordLikeText = ["password", "key", "secret"];
+                const passwordLikeText = ["password", "key", "secret", "token", "connection string", "client secret"];
                 const filter = applyFilter ? blurFilter : resetBlur;
 
                 // Find all input password fields and apply the filter so they appear blurred
@@ -517,6 +517,32 @@ if (window.cloakScriptInjected !== true) {
                                 }
                             });
                         }
+                    });
+                });
+
+                const secureFieldContainers = document.querySelectorAll("[class*='form'], [class*='row'], [role='row'], [role='group'], [class*='section']");
+                secureFieldContainers.forEach((container) => {
+                    const labelCandidates = container.querySelectorAll("label, [role='label'], [class*='label'], [class*='header'], dt, legend");
+                    const hasSecureLabel = Array.from(labelCandidates).some((label) =>
+                        passwordLikeText.some((pwdLikeText) => label.textContent?.toLowerCase()?.includes(pwdLikeText))
+                    );
+                    if (!hasSecureLabel) {
+                        return;
+                    }
+
+                    const valueCandidates = container.querySelectorAll("input:not([type='password']), textarea, [role='textbox'], [class*='value'], [class*='output'], [class*='content'], [class*='text'], code, pre, a[href]");
+                    valueCandidates.forEach((valueCandidate) => {
+                        if (labelCandidates.length > 0 && Array.from(labelCandidates).some((label) => label.contains(valueCandidate))) {
+                            return;
+                        }
+
+                        const valueText = getElementMaskValue(valueCandidate);
+                        if (!valueText || valueText.length < 3) {
+                            return;
+                        }
+
+                        valueCandidate.style.filter = filter;
+                        tryApplyFilterOnElementTitle(valueCandidate, applyFilter, true);
                     });
                 });
             }

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -21,6 +21,8 @@ test('normalizes page rule text for label matching', () => {
 test('matches page rule labels on word boundaries instead of substrings', () => {
     assert.equal(matchesPageRuleLabel('key', 'Storage account key'), true);
     assert.equal(matchesPageRuleLabel('connection string', 'Primary connection string'), true);
+    assert.equal(matchesPageRuleLabel('client secret', 'Client Secret value'), true);
+    assert.equal(matchesPageRuleLabel('token', 'Access token'), true);
     assert.equal(matchesPageRuleLabel('key', 'Search keywords'), false);
     assert.equal(matchesPageRuleLabel('key', 'Keyboard shortcut'), false);
     assert.equal(matchesPageRuleLabel('key 1', 'Key 1'), true);


### PR DESCRIPTION
## Summary
- add a broader label-aware masking pass for form and row containers that are labeled as password, secret, token, key, connection string, or client secret
- blur the displayed values in those containers even when the underlying value does not match an existing regex
- extend label-matching coverage for the new secure field terms

Fixes #22