### PR TITLE
feat: support explicit cloak markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ You can consider this the next-version/update to [Azure Mask](https://github.com
 2. Look for an existing issue that describes your scenario
 3. OR create a new issue
    - Please provide detailed steps to reproduce the issue
+
+## Opt-in page markers
+
+If a product team controls the page markup and wants to explicitly opt content into masking, Cloud Cloak now honors a simple marker contract:
+
+- `data-cloudcloak="cloak"`
+- `data-cloudcloak="mask"`
+- `data-cloudcloak="sensitive"`
+
+Applying one of those attributes to an element tells the extension to blur that element even when the content would not otherwise match a regex or page-specific rule. This is optional and additive; when the marker is absent, Cloud Cloak falls back to its normal masking behavior.

--- a/cloak.js
+++ b/cloak.js
@@ -65,6 +65,19 @@ if (window.cloakScriptInjected !== true) {
                 return `data-cloudcloak-page-rule-${ruleId}`;
             }
 
+            function getExplicitCloakMarkerValue(element) {
+                if (!element || !element.getAttribute) {
+                    return "";
+                }
+
+                return normalizePageRuleText(element.getAttribute("data-cloudcloak"));
+            }
+
+            function shouldForceMaskElement(element) {
+                const markerValue = getExplicitCloakMarkerValue(element);
+                return markerValue === "cloak" || markerValue === "mask" || markerValue === "sensitive";
+            }
+
             function getPageRuleMaskTarget(element, rule) {
                 if (!element) {
                     return null;
@@ -427,7 +440,10 @@ if (window.cloakScriptInjected !== true) {
                 if (node.nodeType === Node.TEXT_NODE || node.nodeName === "INPUT") {
                     tryMatchAndApplyFilterOnTextNode(node, applyFilter);
                 } else if (node.nodeType === Node.ELEMENT_NODE) {
-                    tryApplyFilterOnElementTitle(node, applyFilter);
+                    tryApplyFilterOnElementTitle(node, applyFilter, shouldForceMaskElement(node));
+                    if (shouldForceMaskElement(node)) {
+                        node.style.filter = applyFilter ? blurFilter : resetBlur;
+                    }
 
                     // Handle child nodes
                     for (const child of node.childNodes) {

--- a/common.js
+++ b/common.js
@@ -79,7 +79,7 @@ export const cloakObserverOptions = {
     subtree: true,
     characterData: true,
     attributes: true,
-    attributeFilter: ["title", "class", "style", "hidden", "aria-expanded", "aria-hidden"]
+    attributeFilter: ["title", "class", "style", "hidden", "aria-expanded", "aria-hidden", "data-cloudcloak"]
 };
 
 export function normalizePageRuleText(value) {

--- a/tests/observerConfig.test.mjs
+++ b/tests/observerConfig.test.mjs
@@ -7,7 +7,7 @@ test('observes title and visibility-related attribute mutations for dynamic mask
     assert.equal(cloakObserverOptions.attributes, true);
     assert.deepEqual(
         cloakObserverOptions.attributeFilter,
-        ['title', 'class', 'style', 'hidden', 'aria-expanded', 'aria-hidden']
+        ['title', 'class', 'style', 'hidden', 'aria-expanded', 'aria-hidden', 'data-cloudcloak']
     );
     assert.equal(cloakObserverOptions.childList, true);
     assert.equal(cloakObserverOptions.subtree, true);


### PR DESCRIPTION
## Summary
- add an explicit opt-in marker contract via data-cloudcloak with cloak, mask, and sensitive values
- force masking for marked elements even when the content does not match an existing regex or page rule
- observe data-cloudcloak attribute changes and document the contract in the README

Fixes #19