### PR TITLE
feat: masking hardening and security updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ You can consider this the next-version/update to [Azure Mask](https://github.com
 2. Look for an existing issue that describes your scenario
 3. OR create a new issue
    - Please provide detailed steps to reproduce the issue
+
+## Opt-in page markers
+
+If a product team controls the page markup and wants to explicitly opt content into masking, Cloud Cloak now honors a simple marker contract:
+
+- `data-cloudcloak="cloak"`
+- `data-cloudcloak="mask"`
+- `data-cloudcloak="sensitive"`
+
+Applying one of those attributes to an element tells the extension to blur that element even when the content would not otherwise match a regex or page-specific rule. This is optional and additive; when the marker is absent, Cloud Cloak falls back to its normal masking behavior.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can consider this the next-version/update to [Azure Mask](https://github.com
 1. Navigate to the [Azure Portal](https://portal.azure.com/), [Entra](https://entra.microsoft.com), [GitHub](https://github.com), etc.
 2. Click the extension icon in the toolbar to toggle it from `OFF` to `ON`
 3. Confirm that sensitive data like IP addresses (IPv4 and IPv6), GUIDs, and email addresses are blurred-out
-4. On `github.com` and supported `*.github.com` pages, enable `Hide GitHub Staff Bar` to remove GitHub's staff bar when that bar is present
+4. On `github.com` and supported `*.github.com` pages, enable `Hide GitHub Staff Bar` to remove GitHub's classic staff bar or newer UI Service staffbar when either is present
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can consider this the next-version/update to [Azure Mask](https://github.com
 1. Navigate to the [Azure Portal](https://portal.azure.com/), [Entra](https://entra.microsoft.com), [GitHub](https://github.com), etc.
 2. Click the extension icon in the toolbar to toggle it from `OFF` to `ON`
 3. Confirm that sensitive data like IP addresses (IPv4 and IPv6), GUIDs, and email addresses are blurred-out
-4. On `github.com` and supported `*.github.com` pages, enable `Hide GitHub Staff Bar` to remove GitHub's classic staff bar or newer UI Service staffbar when either is present; GitHub source pages are left alone by the broader masking rules
+4. On `github.com` and supported `*.github.com` pages, enable `Hide GitHub Staff Bar` to remove GitHub's classic staff bar or newer UI Service staffbar when either is present; general masking stays limited to GitHub settings pages so source and diff views are left alone
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can consider this the next-version/update to [Azure Mask](https://github.com
 1. Navigate to the [Azure Portal](https://portal.azure.com/), [Entra](https://entra.microsoft.com), [GitHub](https://github.com), etc.
 2. Click the extension icon in the toolbar to toggle it from `OFF` to `ON`
 3. Confirm that sensitive data like IP addresses (IPv4 and IPv6), GUIDs, and email addresses are blurred-out
-4. On `github.com` and supported `*.github.com` pages, enable `Hide GitHub Staff Bar` to remove GitHub's classic staff bar or newer UI Service staffbar when either is present
+4. On `github.com` and supported `*.github.com` pages, enable `Hide GitHub Staff Bar` to remove GitHub's classic staff bar or newer UI Service staffbar when either is present; GitHub source pages are left alone by the broader masking rules
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -39,3 +39,21 @@ If a product team controls the page markup and wants to explicitly opt content i
 - `data-cloudcloak="sensitive"`
 
 Applying one of those attributes to an element tells the extension to blur that element even when the content would not otherwise match a regex or page-specific rule. This is optional and additive; when the marker is absent, Cloud Cloak falls back to its normal masking behavior.
+
+## Local mock portal for testing
+
+For local manual testing, the repo now includes a lightweight Azure-like mock site under `mock-portal/`.
+
+1. Start the local site:
+   - `npm run dev:site`
+2. Build the dev manifest that allows localhost:
+   - `npm run dev:extension`
+3. In Edge or Chrome, load the extension from the repo folder, but use the generated `dist/manifest.json` for the dev-only localhost-enabled build.
+4. Open `http://localhost:4173/` and walk through the scenario pages:
+   - Storage reveal flows
+   - AI Studio metadata
+   - Dropdowns and tooltips
+   - Secure labeled fields
+   - Explicit `data-cloudcloak` markers
+
+This local harness uses fake data and is intended for regression testing of masking behavior, not for a full Azure Portal clone.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You can consider this the next-version/update to [Azure Mask](https://github.com
 1. Navigate to the [Azure Portal](https://portal.azure.com/), [Entra](https://entra.microsoft.com), [GitHub](https://github.com), etc.
 2. Click the extension icon in the toolbar to toggle it from `OFF` to `ON`
 3. Confirm that sensitive data like IP addresses (IPv4 and IPv6), GUIDs, and email addresses are blurred-out
+4. On `github.com` and supported `*.github.com` pages, enable `Hide GitHub Staff Bar` to remove GitHub's staff bar when that bar is present
 
 ## Reporting Issues
 

--- a/background.js
+++ b/background.js
@@ -23,19 +23,29 @@ function getCurrentStateFromStorageAndUpdateBadge() {
   });
 }
 
-// Inject the cloak script into the current tab/iframes
-async function injectScripts(tabId, frameIds, allFrames) {
-  allFrames = false;
+// Inject the cloak script into the supported frames of the current tab
+async function injectScripts(tabId, frameIds = [0]) {
+  if (!tabId || !frameIds?.length) {
+    return;
+  }
+
   await chrome.scripting.executeScript({
-    target: { tabId, allFrames, frameIds },
+    target: { tabId, frameIds },
     files: ['cloak.js']
   });
 }
 
+async function getSupportedFrameIds(tabId) {
+  const frameDetails = await chrome.webNavigation.getAllFrames({ tabId });
+  return (frameDetails || [])
+    .filter((frameDetail) => isSupportedUrl(frameDetail.url))
+    .map((frameDetail) => frameDetail.frameId);
+}
+
 // This event is triggered when navigation occurs, which can include loading iframes
 chrome.webNavigation.onCommitted.addListener(async (details) => {
-  if (details.frameId !== 0) { // This is an iframe
-    await injectScripts(details.tabId, [details.frameId], false);
+  if (details.frameId !== 0 && isSupportedUrl(details.url)) { // This is a supported iframe
+    await injectScripts(details.tabId, [details.frameId]);
   }
 }, { url: [{ urlMatches: 'https://*/*' }] });
 
@@ -45,7 +55,8 @@ async function tabsEventHandler() {
       const tabUrl = tabs[0]?.url;
       const tabId = tabs[0]?.id;
       if (isSupportedUrl(tabUrl)) {
-        await injectScripts(tabId, null, true);
+        const supportedFrameIds = await getSupportedFrameIds(tabId);
+        await injectScripts(tabId, supportedFrameIds);
         getCurrentStateFromStorageAndUpdateBadge();
       }
     

--- a/cloak.js
+++ b/cloak.js
@@ -431,7 +431,7 @@ if (window.cloakScriptInjected !== true) {
                 }
             }
 
-            function applyFilterOnNode(node, applyFilter) {
+            function applyFilterOnNode(node, applyFilter, shouldRecurse = true) {
                 // Ignore script and style tags
                 if (node.nodeName === "SCRIPT" || node.nodeName === "STYLE" || node.nodeName === "svg" || node.nodeType == Node.COMMENT_NODE) {
                     return;
@@ -446,18 +446,20 @@ if (window.cloakScriptInjected !== true) {
                     }
 
                     // Handle child nodes
-                    for (const child of node.childNodes) {
-                        if ((child.nodeType === Node.TEXT_NODE || child.nodeName === "INPUT") && tryMatchAndApplyFilterOnTextNode(child, applyFilter)) {
-                            break;
-                        }
+                    if (shouldRecurse) {
+                        for (const child of node.childNodes) {
+                            if ((child.nodeType === Node.TEXT_NODE || child.nodeName === "INPUT") && tryMatchAndApplyFilterOnTextNode(child, applyFilter)) {
+                                break;
+                            }
 
-                        // Recurse into child nodes
-                        if (child.childNodes && child.childNodes.length > 0) {
-                            applyFilterOnNode(child, applyFilter);
+                            // Recurse into child nodes
+                            if (child.childNodes && child.childNodes.length > 0) {
+                                applyFilterOnNode(child, applyFilter);
+                            }
                         }
                     }
 
-                    if (node.shadowRoot && node.shadowRoot.childNodes.length > 0) {
+                    if (shouldRecurse && node.shadowRoot && node.shadowRoot.childNodes.length > 0) {
                         applyFilterOnNode(node.shadowRoot, applyFilter);
                     }
                 }
@@ -540,7 +542,7 @@ if (window.cloakScriptInjected !== true) {
                 secureFieldContainers.forEach((container) => {
                     const labelCandidates = container.querySelectorAll("label, [role='label'], [class*='label'], [class*='header'], dt, legend");
                     const hasSecureLabel = Array.from(labelCandidates).some((label) =>
-                        passwordLikeText.some((pwdLikeText) => label.textContent?.toLowerCase()?.includes(pwdLikeText))
+                        passwordLikeText.some((pwdLikeText) => matchesPageRuleLabel(pwdLikeText, label.textContent))
                     );
                     if (!hasSecureLabel) {
                         return;
@@ -600,7 +602,8 @@ if (window.cloakScriptInjected !== true) {
                             applyFilterOnNode(mutation.target, true);
                         }
                         if (mutation.type === 'attributes') {
-                            applyFilterOnNode(mutation.target, true);
+                            const shouldDeepScan = mutation.attributeName !== 'class' && mutation.attributeName !== 'style';
+                            applyFilterOnNode(mutation.target, true, shouldDeepScan);
                         }
                         mutation.addedNodes.forEach((node) => {
                             applyFilterOnNode(node, true /* If observer is running we are in cloak mode */);

--- a/cloak.js
+++ b/cloak.js
@@ -65,6 +65,19 @@ if (window.cloakScriptInjected !== true) {
                 return `data-cloudcloak-page-rule-${ruleId}`;
             }
 
+            function getExplicitCloakMarkerValue(element) {
+                if (!element || !element.getAttribute) {
+                    return "";
+                }
+
+                return normalizePageRuleText(element.getAttribute("data-cloudcloak"));
+            }
+
+            function shouldForceMaskElement(element) {
+                const markerValue = getExplicitCloakMarkerValue(element);
+                return markerValue === "cloak" || markerValue === "mask" || markerValue === "sensitive";
+            }
+
             function getPageRuleMaskTarget(element, rule) {
                 if (!element) {
                     return null;
@@ -427,7 +440,10 @@ if (window.cloakScriptInjected !== true) {
                 if (node.nodeType === Node.TEXT_NODE || node.nodeName === "INPUT") {
                     tryMatchAndApplyFilterOnTextNode(node, applyFilter);
                 } else if (node.nodeType === Node.ELEMENT_NODE) {
-                    tryApplyFilterOnElementTitle(node, applyFilter);
+                    tryApplyFilterOnElementTitle(node, applyFilter, shouldForceMaskElement(node));
+                    if (shouldForceMaskElement(node)) {
+                        node.style.filter = applyFilter ? blurFilter : resetBlur;
+                    }
 
                     // Handle child nodes
                     for (const child of node.childNodes) {

--- a/cloak.js
+++ b/cloak.js
@@ -5,6 +5,7 @@ if (window.cloakScriptInjected !== true) {
         const src = chrome.runtime.getURL("./common.js");
         import(src).then((commonModule) => {
             const cloakablePatterns = commonModule.cloakablePatterns;
+            const cloakObserverOptions = commonModule.cloakObserverOptions;
             const matchesPageRuleLabel = commonModule.matchesPageRuleLabel;
             const pageSpecificRules = commonModule.pageSpecificRules || [];
             const isPageRuleActive = commonModule.isPageRuleActive;
@@ -408,6 +409,8 @@ if (window.cloakScriptInjected !== true) {
                 if (node.nodeType === Node.TEXT_NODE || node.nodeName === "INPUT") {
                     tryMatchAndApplyFilterOnTextNode(node, applyFilter);
                 } else if (node.nodeType === Node.ELEMENT_NODE) {
+                    tryApplyFilterOnElementTitle(node, applyFilter);
+
                     // Handle child nodes
                     for (const child of node.childNodes) {
                         if ((child.nodeType === Node.TEXT_NODE || child.nodeName === "INPUT") && tryMatchAndApplyFilterOnTextNode(child, applyFilter)) {
@@ -516,11 +519,7 @@ if (window.cloakScriptInjected !== true) {
                 if (window.regexPatternsArray?.length > 0 || window.toggleStates?.secrets || window.toggleStates?.subscriptioninfo) {
                     getAllNodesAndApplyFilter(true);
                     window.cloakObserver && window.cloakObserver.disconnect();
-                    window.cloakObserver && window.cloakObserver.observe(document.body, {
-                        childList: true,    // Watch for added/removed elements
-                        subtree: true,      // Watch the entire subtree of the document
-                        characterData: true // Watch for text content changes (SPA updates)
-                    });
+                    window.cloakObserver && window.cloakObserver.observe(document.body, cloakObserverOptions);
                 } else {
                     getAllNodesAndApplyFilter(false);
                     window.cloakObserver && window.cloakObserver.disconnect();
@@ -538,6 +537,9 @@ if (window.cloakScriptInjected !== true) {
                     for (const mutation of mutationList) {
                         if (mutation.type === 'characterData') {
                             // Text content changed in-place (common in SPAs like Azure Portal)
+                            applyFilterOnNode(mutation.target, true);
+                        }
+                        if (mutation.type === 'attributes') {
                             applyFilterOnNode(mutation.target, true);
                         }
                         mutation.addedNodes.forEach((node) => {

--- a/cloak.js
+++ b/cloak.js
@@ -311,6 +311,7 @@ if (window.cloakScriptInjected !== true) {
                     schedulePageSpecificRuleRescan();
                 };
 
+                document.addEventListener("mousedown", scheduleTrustedRescan, true);
                 document.addEventListener("click", scheduleTrustedRescan, true);
                 document.addEventListener("keydown", scheduleTrustedRescan, true);
                 window.pageRuleInteractionHandlersRegistered = true;

--- a/cloak.js
+++ b/cloak.js
@@ -481,7 +481,7 @@ if (window.cloakScriptInjected !== true) {
             }
 
             function specialHandlingForPasswordFieldsAndTablesWithSecrets(applyFilter) {
-                const passwordLikeText = ["password", "key", "secret"];
+                const passwordLikeText = ["password", "key", "secret", "token", "connection string", "client secret"];
                 const filter = applyFilter ? blurFilter : resetBlur;
 
                 // Find all input password fields and apply the filter so they appear blurred
@@ -517,6 +517,32 @@ if (window.cloakScriptInjected !== true) {
                                 }
                             });
                         }
+                    });
+                });
+
+                const secureFieldContainers = document.querySelectorAll("[class*='form'], [class*='row'], [role='row'], [role='group'], [class*='section']");
+                secureFieldContainers.forEach((container) => {
+                    const labelCandidates = container.querySelectorAll("label, [role='label'], [class*='label'], [class*='header'], dt, legend");
+                    const hasSecureLabel = Array.from(labelCandidates).some((label) =>
+                        passwordLikeText.some((pwdLikeText) => label.textContent?.toLowerCase()?.includes(pwdLikeText))
+                    );
+                    if (!hasSecureLabel) {
+                        return;
+                    }
+
+                    const valueCandidates = container.querySelectorAll("input:not([type='password']), textarea, [role='textbox'], [class*='value'], [class*='output'], [class*='content'], [class*='text'], code, pre, a[href]");
+                    valueCandidates.forEach((valueCandidate) => {
+                        if (labelCandidates.length > 0 && Array.from(labelCandidates).some((label) => label.contains(valueCandidate))) {
+                            return;
+                        }
+
+                        const valueText = getElementMaskValue(valueCandidate);
+                        if (!valueText || valueText.length < 3) {
+                            return;
+                        }
+
+                        valueCandidate.style.filter = filter;
+                        tryApplyFilterOnElementTitle(valueCandidate, applyFilter, true);
                     });
                 });
             }

--- a/cloak.js
+++ b/cloak.js
@@ -65,6 +65,18 @@ if (window.cloakScriptInjected !== true) {
                 return `data-cloudcloak-page-rule-${ruleId}`;
             }
 
+            function getPageRuleMaskTarget(element, rule) {
+                if (!element) {
+                    return null;
+                }
+
+                if (!rule?.maskClosestSelector) {
+                    return element;
+                }
+
+                return element.closest(rule.maskClosestSelector) || element;
+            }
+
             function getActivePageRules() {
                 return pageSpecificRules.filter((rule) => isPageRuleActive(rule, window.location.href, window.toggleStates));
             }
@@ -223,6 +235,7 @@ if (window.cloakScriptInjected !== true) {
             function runContextAwarePageRule(rule, shouldCloak) {
                 const candidateSelectors = (rule.valueSelectors || []).join(", ");
                 const matchedElements = [];
+                const matchedElementSet = new Set();
                 if (candidateSelectors) {
                     document.querySelectorAll(candidateSelectors).forEach((element) => {
                         const elementValue = getElementMaskValue(element);
@@ -235,7 +248,11 @@ if (window.cloakScriptInjected !== true) {
                         const hasNearbyActions = meetsMinimumValueLength && elementHasNearbyRuleActions(element, rule);
 
                         if (matchesRuleContext || hasNearbyActions) {
-                            matchedElements.push(element);
+                            const maskTarget = getPageRuleMaskTarget(element, rule);
+                            if (maskTarget && !matchedElementSet.has(maskTarget)) {
+                                matchedElementSet.add(maskTarget);
+                                matchedElements.push(maskTarget);
+                            }
                         }
                     });
                 }

--- a/cloak.js
+++ b/cloak.js
@@ -570,7 +570,7 @@ if (window.cloakScriptInjected !== true) {
                     return;
                 }
 
-                const staffBar = document.querySelector("#serverstats[aria-label='Staff Bar'], section#serverstats.server-stats");
+                const staffBar = document.querySelector("#serverstats[aria-label='Staff Bar'], section#serverstats.server-stats, aside[aria-label='Staffbar']");
                 const originalDisplayAttribute = "data-cloudcloak-staffbar-display";
                 if (!staffBar) {
                     return;

--- a/cloak.js
+++ b/cloak.js
@@ -9,11 +9,13 @@ if (window.cloakScriptInjected !== true) {
             const matchesPageRuleLabel = commonModule.matchesPageRuleLabel;
             const pageSpecificRules = commonModule.pageSpecificRules || [];
             const isPageRuleActive = commonModule.isPageRuleActive;
+            const isGitHubUrl = commonModule.isGitHubUrl;
             const normalizePageRuleText = commonModule.normalizePageRuleText;
             const shouldHideGitHubStaffBar = commonModule.shouldHideGitHubStaffBar;
             const blurFilter = "blur(5px)";
             const maskText = "*****";
             const resetBlur = "none";
+            const shouldSkipGeneralMasking = isGitHubUrl(window.location.href);
 
             window.regexPatternsArray;
             window.toggleStates;
@@ -600,13 +602,17 @@ if (window.cloakScriptInjected !== true) {
             }
 
             function getAllNodesAndApplyFilter(applyFilter) {
+                setGitHubStaffBarVisibility(!!window.toggleStates?.githubstaffbar && applyFilter);
+                if (shouldSkipGeneralMasking) {
+                    return;
+                }
+
                 if (document.body) {
                     applyFilterOnNode(document.body, applyFilter);
                 }
 
                 specialHandlingForPasswordFieldsAndTablesWithSecrets(applyFilter);
                 specialHandlingForAzurePortalEssentialsValues(!!window.toggleStates?.subscriptioninfo && applyFilter);
-                setGitHubStaffBarVisibility(!!window.toggleStates?.githubstaffbar && applyFilter);
                 runPageSpecificRules(applyFilter);
             }
             function toggleCloak() {
@@ -614,7 +620,14 @@ if (window.cloakScriptInjected !== true) {
                 updateRegexPatterns();
                 ensurePageRuleInteractionHandlers();
 
-                if (window.regexPatternsArray?.length > 0 || window.toggleStates?.secrets || window.toggleStates?.subscriptioninfo || window.toggleStates?.githubstaffbar) {
+                const shouldRunGeneralMasking = !shouldSkipGeneralMasking && (
+                    window.regexPatternsArray?.length > 0 ||
+                    window.toggleStates?.secrets ||
+                    window.toggleStates?.subscriptioninfo
+                );
+                const shouldRunGitHubStaffBar = shouldSkipGeneralMasking && !!window.toggleStates?.githubstaffbar;
+
+                if (shouldRunGeneralMasking || shouldRunGitHubStaffBar) {
                     getAllNodesAndApplyFilter(true);
                     window.cloakObserver && window.cloakObserver.disconnect();
                     window.cloakObserver && window.cloakObserver.observe(document.body, cloakObserverOptions);
@@ -632,6 +645,11 @@ if (window.cloakScriptInjected !== true) {
             if (!window.cloakObserver) {
                 window.cloakObserver = new MutationObserver((mutationList) => {
                     // Go through the mutations and apply the filter on the added/changed nodes
+                    if (shouldSkipGeneralMasking) {
+                        setGitHubStaffBarVisibility(!!window.toggleStates?.githubstaffbar /* If observer is running we are in cloak mode */);
+                        return;
+                    }
+
                     for (const mutation of mutationList) {
                         if (mutation.type === 'characterData') {
                             // Text content changed in-place (common in SPAs like Azure Portal)

--- a/cloak.js
+++ b/cloak.js
@@ -10,12 +10,16 @@ if (window.cloakScriptInjected !== true) {
             const pageSpecificRules = commonModule.pageSpecificRules || [];
             const isPageRuleActive = commonModule.isPageRuleActive;
             const isGitHubUrl = commonModule.isGitHubUrl;
+            const isGitHubSettingsUrl = commonModule.isGitHubSettingsUrl;
             const normalizePageRuleText = commonModule.normalizePageRuleText;
             const shouldHideGitHubStaffBar = commonModule.shouldHideGitHubStaffBar;
             const blurFilter = "blur(5px)";
             const maskText = "*****";
             const resetBlur = "none";
-            const shouldSkipGeneralMasking = isGitHubUrl(window.location.href);
+
+            function shouldSkipGeneralMasking() {
+                return isGitHubUrl(window.location.href) && !isGitHubSettingsUrl(window.location.href);
+            }
 
             window.regexPatternsArray;
             window.toggleStates;
@@ -603,7 +607,7 @@ if (window.cloakScriptInjected !== true) {
 
             function getAllNodesAndApplyFilter(applyFilter) {
                 setGitHubStaffBarVisibility(!!window.toggleStates?.githubstaffbar && applyFilter);
-                if (shouldSkipGeneralMasking) {
+                if (shouldSkipGeneralMasking()) {
                     return;
                 }
 
@@ -620,12 +624,12 @@ if (window.cloakScriptInjected !== true) {
                 updateRegexPatterns();
                 ensurePageRuleInteractionHandlers();
 
-                const shouldRunGeneralMasking = !shouldSkipGeneralMasking && (
+                const shouldRunGeneralMasking = !shouldSkipGeneralMasking() && (
                     window.regexPatternsArray?.length > 0 ||
                     window.toggleStates?.secrets ||
                     window.toggleStates?.subscriptioninfo
                 );
-                const shouldRunGitHubStaffBar = shouldSkipGeneralMasking && !!window.toggleStates?.githubstaffbar;
+                const shouldRunGitHubStaffBar = isGitHubUrl(window.location.href) && !!window.toggleStates?.githubstaffbar;
 
                 if (shouldRunGeneralMasking || shouldRunGitHubStaffBar) {
                     getAllNodesAndApplyFilter(true);
@@ -645,7 +649,7 @@ if (window.cloakScriptInjected !== true) {
             if (!window.cloakObserver) {
                 window.cloakObserver = new MutationObserver((mutationList) => {
                     // Go through the mutations and apply the filter on the added/changed nodes
-                    if (shouldSkipGeneralMasking) {
+                    if (shouldSkipGeneralMasking()) {
                         setGitHubStaffBarVisibility(!!window.toggleStates?.githubstaffbar /* If observer is running we are in cloak mode */);
                         return;
                     }

--- a/cloak.js
+++ b/cloak.js
@@ -10,6 +10,7 @@ if (window.cloakScriptInjected !== true) {
             const pageSpecificRules = commonModule.pageSpecificRules || [];
             const isPageRuleActive = commonModule.isPageRuleActive;
             const normalizePageRuleText = commonModule.normalizePageRuleText;
+            const shouldHideGitHubStaffBar = commonModule.shouldHideGitHubStaffBar;
             const blurFilter = "blur(5px)";
             const maskText = "*****";
             const resetBlur = "none";
@@ -564,6 +565,40 @@ if (window.cloakScriptInjected !== true) {
                     });
                 });
             }
+            function setGitHubStaffBarVisibility(shouldHide) {
+                if (!shouldHideGitHubStaffBar(window.location.href)) {
+                    return;
+                }
+
+                const staffBar = document.querySelector("#serverstats[aria-label='Staff Bar'], section#serverstats.server-stats");
+                const originalDisplayAttribute = "data-cloudcloak-staffbar-display";
+                if (!staffBar) {
+                    return;
+                }
+
+                if (shouldHide) {
+                    if (!staffBar.hasAttribute(originalDisplayAttribute)) {
+                        staffBar.setAttribute(originalDisplayAttribute, staffBar.style.display || "");
+                    }
+                    if (staffBar.style.display !== "none") {
+                        staffBar.style.display = "none";
+                    }
+                    return;
+                }
+
+                if (!staffBar.hasAttribute(originalDisplayAttribute)) {
+                    return;
+                }
+
+                const originalDisplay = staffBar.getAttribute(originalDisplayAttribute);
+                if (originalDisplay) {
+                    staffBar.style.display = originalDisplay;
+                } else {
+                    staffBar.style.removeProperty("display");
+                }
+                staffBar.removeAttribute(originalDisplayAttribute);
+            }
+
             function getAllNodesAndApplyFilter(applyFilter) {
                 if (document.body) {
                     applyFilterOnNode(document.body, applyFilter);
@@ -571,6 +606,7 @@ if (window.cloakScriptInjected !== true) {
 
                 specialHandlingForPasswordFieldsAndTablesWithSecrets(applyFilter);
                 specialHandlingForAzurePortalEssentialsValues(!!window.toggleStates?.subscriptioninfo && applyFilter);
+                setGitHubStaffBarVisibility(!!window.toggleStates?.githubstaffbar && applyFilter);
                 runPageSpecificRules(applyFilter);
             }
             function toggleCloak() {
@@ -578,7 +614,7 @@ if (window.cloakScriptInjected !== true) {
                 updateRegexPatterns();
                 ensurePageRuleInteractionHandlers();
 
-                if (window.regexPatternsArray?.length > 0 || window.toggleStates?.secrets || window.toggleStates?.subscriptioninfo) {
+                if (window.regexPatternsArray?.length > 0 || window.toggleStates?.secrets || window.toggleStates?.subscriptioninfo || window.toggleStates?.githubstaffbar) {
                     getAllNodesAndApplyFilter(true);
                     window.cloakObserver && window.cloakObserver.disconnect();
                     window.cloakObserver && window.cloakObserver.observe(document.body, cloakObserverOptions);
@@ -615,6 +651,7 @@ if (window.cloakScriptInjected !== true) {
                     window.secretHandlingTimeout = setTimeout(() => {
                         specialHandlingForPasswordFieldsAndTablesWithSecrets(true /* If observer is running we are in cloak mode */);
                         specialHandlingForAzurePortalEssentialsValues(!!window.toggleStates?.subscriptioninfo && true /* If observer is running we are in cloak mode */);
+                        setGitHubStaffBarVisibility(!!window.toggleStates?.githubstaffbar /* If observer is running we are in cloak mode */);
                         runPageSpecificRules(true /* If observer is running we are in cloak mode */);
                     }, 50);
                 });

--- a/common.js
+++ b/common.js
@@ -79,7 +79,7 @@ export const cloakObserverOptions = {
     subtree: true,
     characterData: true,
     attributes: true,
-    attributeFilter: ["title", "class", "style", "hidden", "aria-expanded", "aria-hidden"]
+    attributeFilter: ["title", "class", "style", "hidden", "aria-expanded", "aria-hidden", "data-cloudcloak"]
 };
 
 export function normalizePageRuleText(value) {

--- a/common.js
+++ b/common.js
@@ -79,7 +79,7 @@ export const cloakObserverOptions = {
     subtree: true,
     characterData: true,
     attributes: true,
-    attributeFilter: ["title"]
+    attributeFilter: ["title", "class", "style", "hidden", "aria-expanded", "aria-hidden"]
 };
 
 export function normalizePageRuleText(value) {

--- a/common.js
+++ b/common.js
@@ -62,6 +62,14 @@ export function isSupportedUrl(url) {
     });
 }
 
+export const cloakObserverOptions = {
+    childList: true,
+    subtree: true,
+    characterData: true,
+    attributes: true,
+    attributeFilter: ["title"]
+};
+
 export function normalizePageRuleText(value) {
     return (value || "")
         .replace(/\s+/g, " ")

--- a/common.js
+++ b/common.js
@@ -163,19 +163,31 @@ export const pageSpecificRules = [
             "key 2",
             "api key",
             "access key",
-            "secret"
+            "secret",
+            "created by",
+            "modified by",
+            "endpoint",
+            "endpoint uri",
+            "base url"
         ],
         valueSelectors: [
             "input",
             "textarea",
             "[role='textbox']",
-            "[class*='value']"
+            "[class*='value']",
+            "[class*='output']",
+            "[class*='content']",
+            "[class*='text']",
+            "code",
+            "pre",
+            "a[href]"
         ],
         nearbyActionLabels: [
             "show",
             "hide",
             "copy"
         ],
+        maskClosestSelector: "[class*='form'], [class*='row'], [role='row'], [role='group'], [class*='section']",
         minimumValueLength: 16,
         actionSearchDepth: 4,
         interactionRescanDelays: [0, 75, 250, 500, 1000]

--- a/common.js
+++ b/common.js
@@ -23,6 +23,18 @@ export const supportedDomains = [
     'https://*.reactblade.portal.azure.net'
 ];
 
+const exactSupportedHostPermissionPatterns = supportedDomains
+    .filter((supportedDomain) => !supportedDomain.includes('*'))
+    .map((supportedDomain) => `${supportedDomain}/*`);
+
+export const supportedHostPermissionPatterns = [
+    ...exactSupportedHostPermissionPatterns,
+    'https://*.reactblade-ms.portal.azure.net/*',
+    'https://*.reactblade.portal.azure.net/*',
+    // Chrome host match patterns cannot express reactblade-ms*.portal.azure.net or reactblade*.portal.azure.net.
+    'https://*.portal.azure.net/*'
+];
+
 function escapeRegex(value) {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/common.js
+++ b/common.js
@@ -128,7 +128,12 @@ export const pageSpecificRules = [
             "input",
             "textarea",
             "[role='textbox']",
-            "[class*='value']"
+            "[class*='value']",
+            "[class*='output']",
+            "[class*='content']",
+            "[class*='text']",
+            "code",
+            "pre"
         ],
         nearbyActionLabels: [
             "show",
@@ -138,6 +143,7 @@ export const pageSpecificRules = [
             "generate sas",
             "generate sas and connection string"
         ],
+        maskClosestSelector: "[class*='fxc-gc'], [class*='form'], [class*='row'], [role='row'], [role='group']",
         minimumValueLength: 16,
         actionSearchDepth: 4,
         interactionRescanDelays: [0, 75, 250, 500, 1000]

--- a/common.js
+++ b/common.js
@@ -101,6 +101,14 @@ export function shouldHideGitHubStaffBar(url) {
         return false;
     }
 
+    return isGitHubUrl(url);
+}
+
+export function isGitHubUrl(url) {
+    if (!url) {
+        return false;
+    }
+
     const currentUrl = new URL(url);
     return currentUrl.protocol === 'https:' &&
         (currentUrl.hostname === 'github.com' || currentUrl.hostname.endsWith('.github.com'));

--- a/common.js
+++ b/common.js
@@ -114,6 +114,15 @@ export function isGitHubUrl(url) {
         (currentUrl.hostname === 'github.com' || currentUrl.hostname.endsWith('.github.com'));
 }
 
+export function isGitHubSettingsUrl(url) {
+    if (!isGitHubUrl(url)) {
+        return false;
+    }
+
+    const currentUrl = new URL(url);
+    return currentUrl.pathname.includes('/settings');
+}
+
 export const cloakObserverOptions = {
     childList: true,
     subtree: true,

--- a/common.js
+++ b/common.js
@@ -1,4 +1,4 @@
-export const supportedDomains = [
+const baseSupportedDomains = [
     'https://portal.azure.com',
     'https://ms.portal.azure.com',
     'https://rc.portal.azure.com',
@@ -23,7 +23,27 @@ export const supportedDomains = [
     'https://*.reactblade.portal.azure.net'
 ];
 
-const exactSupportedHostPermissionPatterns = supportedDomains
+export const localTestHostPermissionPatterns = [
+    'http://localhost:4173/*',
+    'http://127.0.0.1:4173/*'
+];
+
+export const localTestDomains = localTestHostPermissionPatterns.map((pattern) => pattern.replace('/*', ''));
+
+function shouldEnableLocalTestDomains() {
+    if (typeof chrome === 'undefined' || !chrome.runtime?.getManifest) {
+        return false;
+    }
+
+    const hostPermissions = chrome.runtime.getManifest().host_permissions || [];
+    return localTestHostPermissionPatterns.some((pattern) => hostPermissions.includes(pattern));
+}
+
+export const supportedDomains = shouldEnableLocalTestDomains()
+    ? [...baseSupportedDomains, ...localTestDomains]
+    : [...baseSupportedDomains];
+
+const exactSupportedHostPermissionPatterns = baseSupportedDomains
     .filter((supportedDomain) => !supportedDomain.includes('*'))
     .map((supportedDomain) => `${supportedDomain}/*`);
 

--- a/common.js
+++ b/common.js
@@ -13,6 +13,7 @@ const baseSupportedDomains = [
     'https://make.preview.powerapps.com',
     'https://msazure.visualstudio.com',
     'https://github.com',
+    'https://*.github.com',
     'https://copilotstudio.microsoft.com',
     'https://copilotstudio.preview.microsoft.com',
     'https://reactblade-ms.portal.azure.net',
@@ -51,6 +52,7 @@ export const supportedHostPermissionPatterns = [
     ...exactSupportedHostPermissionPatterns,
     'https://*.reactblade-ms.portal.azure.net/*',
     'https://*.reactblade.portal.azure.net/*',
+    'https://*.github.com/*',
     // Chrome host match patterns cannot express reactblade-ms*.portal.azure.net or reactblade*.portal.azure.net.
     'https://*.portal.azure.net/*'
 ];
@@ -92,6 +94,16 @@ export function isSupportedUrl(url) {
         return currentUrl.protocol === supportedDomainMatcher.protocol &&
             supportedDomainMatcher.hostnameRegex.test(currentUrl.hostname);
     });
+}
+
+export function shouldHideGitHubStaffBar(url) {
+    if (!url) {
+        return false;
+    }
+
+    const currentUrl = new URL(url);
+    return currentUrl.protocol === 'https:' &&
+        (currentUrl.hostname === 'github.com' || currentUrl.hostname.endsWith('.github.com'));
 }
 
 export const cloakObserverOptions = {
@@ -299,6 +311,12 @@ export const cloakablePatterns = [
         id: 'subscriptioninfo',
         label: 'Subscription Info',
         category: 'Subscription Info',
+        regexes: []
+    },
+    {
+        id: 'githubstaffbar',
+        label: 'Hide GitHub Staff Bar',
+        category: 'GitHub',
         regexes: []
     }
 ];

--- a/dist/manifest.dev.json
+++ b/dist/manifest.dev.json
@@ -1,0 +1,88 @@
+{
+  "manifest_version": 3,
+  "name": "Cloud Cloak",
+  "description": "Enables 'cloak mode' for Microsoft Cloud Portals",
+  "version": "1.0",
+  "icons": {
+    "16": "images/icon-16.png",
+    "32": "images/icon-32.png",
+    "48": "images/icon-48.png",
+    "128": "images/icon-128.png"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "images/icon-16.png",
+      "32": "images/icon-32.png",
+      "48": "images/icon-48.png",
+      "128": "images/icon-128.png"
+    }
+  },
+  "web_accessible_resources": [
+    {
+      "matches": [
+        "https://portal.azure.com/*",
+        "https://ms.portal.azure.com/*",
+        "https://rc.portal.azure.com/*",
+        "https://preview.portal.azure.com/*",
+        "https://entra.microsoft.com/*",
+        "https://intune.microsoft.com/*",
+        "https://ai.azure.com/*",
+        "https://admin.microsoft.com/*",
+        "https://sip.security.microsoft.com/*",
+        "https://purview.microsoft.com/*",
+        "https://make.powerapps.com/*",
+        "https://make.preview.powerapps.com/*",
+        "https://msazure.visualstudio.com/*",
+        "https://github.com/*",
+        "https://copilotstudio.microsoft.com/*",
+        "https://copilotstudio.preview.microsoft.com/*",
+        "https://reactblade-ms.portal.azure.net/*",
+        "https://reactblade.portal.azure.net/*",
+        "https://*.reactblade-ms.portal.azure.net/*",
+        "https://*.reactblade.portal.azure.net/*",
+        "https://*.portal.azure.net/*",
+        "http://localhost:4173/*",
+        "http://127.0.0.1:4173/*"
+      ],
+      "resources": [
+        "common.js"
+      ]
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "webNavigation",
+    "storage"
+  ],
+  "host_permissions": [
+    "https://portal.azure.com/*",
+    "https://ms.portal.azure.com/*",
+    "https://rc.portal.azure.com/*",
+    "https://preview.portal.azure.com/*",
+    "https://entra.microsoft.com/*",
+    "https://intune.microsoft.com/*",
+    "https://ai.azure.com/*",
+    "https://admin.microsoft.com/*",
+    "https://sip.security.microsoft.com/*",
+    "https://purview.microsoft.com/*",
+    "https://make.powerapps.com/*",
+    "https://make.preview.powerapps.com/*",
+    "https://msazure.visualstudio.com/*",
+    "https://github.com/*",
+    "https://copilotstudio.microsoft.com/*",
+    "https://copilotstudio.preview.microsoft.com/*",
+    "https://reactblade-ms.portal.azure.net/*",
+    "https://reactblade.portal.azure.net/*",
+    "https://*.reactblade-ms.portal.azure.net/*",
+    "https://*.reactblade.portal.azure.net/*",
+    "https://*.portal.azure.net/*",
+    "http://localhost:4173/*",
+    "http://127.0.0.1:4173/*"
+  ]
+}

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,0 +1,88 @@
+{
+  "manifest_version": 3,
+  "name": "Cloud Cloak",
+  "description": "Enables 'cloak mode' for Microsoft Cloud Portals",
+  "version": "1.0",
+  "icons": {
+    "16": "images/icon-16.png",
+    "32": "images/icon-32.png",
+    "48": "images/icon-48.png",
+    "128": "images/icon-128.png"
+  },
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "images/icon-16.png",
+      "32": "images/icon-32.png",
+      "48": "images/icon-48.png",
+      "128": "images/icon-128.png"
+    }
+  },
+  "web_accessible_resources": [
+    {
+      "matches": [
+        "https://portal.azure.com/*",
+        "https://ms.portal.azure.com/*",
+        "https://rc.portal.azure.com/*",
+        "https://preview.portal.azure.com/*",
+        "https://entra.microsoft.com/*",
+        "https://intune.microsoft.com/*",
+        "https://ai.azure.com/*",
+        "https://admin.microsoft.com/*",
+        "https://sip.security.microsoft.com/*",
+        "https://purview.microsoft.com/*",
+        "https://make.powerapps.com/*",
+        "https://make.preview.powerapps.com/*",
+        "https://msazure.visualstudio.com/*",
+        "https://github.com/*",
+        "https://copilotstudio.microsoft.com/*",
+        "https://copilotstudio.preview.microsoft.com/*",
+        "https://reactblade-ms.portal.azure.net/*",
+        "https://reactblade.portal.azure.net/*",
+        "https://*.reactblade-ms.portal.azure.net/*",
+        "https://*.reactblade.portal.azure.net/*",
+        "https://*.portal.azure.net/*",
+        "http://localhost:4173/*",
+        "http://127.0.0.1:4173/*"
+      ],
+      "resources": [
+        "common.js"
+      ]
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "scripting",
+    "webNavigation",
+    "storage"
+  ],
+  "host_permissions": [
+    "https://portal.azure.com/*",
+    "https://ms.portal.azure.com/*",
+    "https://rc.portal.azure.com/*",
+    "https://preview.portal.azure.com/*",
+    "https://entra.microsoft.com/*",
+    "https://intune.microsoft.com/*",
+    "https://ai.azure.com/*",
+    "https://admin.microsoft.com/*",
+    "https://sip.security.microsoft.com/*",
+    "https://purview.microsoft.com/*",
+    "https://make.powerapps.com/*",
+    "https://make.preview.powerapps.com/*",
+    "https://msazure.visualstudio.com/*",
+    "https://github.com/*",
+    "https://copilotstudio.microsoft.com/*",
+    "https://copilotstudio.preview.microsoft.com/*",
+    "https://reactblade-ms.portal.azure.net/*",
+    "https://reactblade.portal.azure.net/*",
+    "https://*.reactblade-ms.portal.azure.net/*",
+    "https://*.reactblade.portal.azure.net/*",
+    "https://*.portal.azure.net/*",
+    "http://localhost:4173/*",
+    "http://127.0.0.1:4173/*"
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,29 @@
     }
   },
   "web_accessible_resources": [{
-     "matches": ["<all_urls>"],
+     "matches": [
+       "https://portal.azure.com/*",
+       "https://ms.portal.azure.com/*",
+       "https://rc.portal.azure.com/*",
+       "https://preview.portal.azure.com/*",
+       "https://entra.microsoft.com/*",
+       "https://intune.microsoft.com/*",
+       "https://ai.azure.com/*",
+       "https://admin.microsoft.com/*",
+       "https://sip.security.microsoft.com/*",
+       "https://purview.microsoft.com/*",
+       "https://make.powerapps.com/*",
+       "https://make.preview.powerapps.com/*",
+       "https://msazure.visualstudio.com/*",
+       "https://github.com/*",
+       "https://copilotstudio.microsoft.com/*",
+       "https://copilotstudio.preview.microsoft.com/*",
+       "https://reactblade-ms.portal.azure.net/*",
+       "https://reactblade.portal.azure.net/*",
+       "https://*.reactblade-ms.portal.azure.net/*",
+       "https://*.reactblade.portal.azure.net/*",
+       "https://*.portal.azure.net/*"
+     ],
      "resources": ["common.js"]
    }],
   "permissions": [
@@ -33,6 +55,26 @@
     "storage"
   ],
   "host_permissions": [
-    "https://*/"
+    "https://portal.azure.com/*",
+    "https://ms.portal.azure.com/*",
+    "https://rc.portal.azure.com/*",
+    "https://preview.portal.azure.com/*",
+    "https://entra.microsoft.com/*",
+    "https://intune.microsoft.com/*",
+    "https://ai.azure.com/*",
+    "https://admin.microsoft.com/*",
+    "https://sip.security.microsoft.com/*",
+    "https://purview.microsoft.com/*",
+    "https://make.powerapps.com/*",
+    "https://make.preview.powerapps.com/*",
+    "https://msazure.visualstudio.com/*",
+    "https://github.com/*",
+    "https://copilotstudio.microsoft.com/*",
+    "https://copilotstudio.preview.microsoft.com/*",
+    "https://reactblade-ms.portal.azure.net/*",
+    "https://reactblade.portal.azure.net/*",
+    "https://*.reactblade-ms.portal.azure.net/*",
+    "https://*.reactblade.portal.azure.net/*",
+    "https://*.portal.azure.net/*"
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -44,6 +44,7 @@
        "https://reactblade.portal.azure.net/*",
        "https://*.reactblade-ms.portal.azure.net/*",
        "https://*.reactblade.portal.azure.net/*",
+       "https://*.github.com/*",
        "https://*.portal.azure.net/*"
      ],
      "resources": ["common.js"]
@@ -75,6 +76,7 @@
     "https://reactblade.portal.azure.net/*",
     "https://*.reactblade-ms.portal.azure.net/*",
     "https://*.reactblade.portal.azure.net/*",
+    "https://*.github.com/*",
     "https://*.portal.azure.net/*"
   ]
 }

--- a/mock-portal/ai-studio-metadata.html
+++ b/mock-portal/ai-studio-metadata.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock AI Studio Metadata</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <div class="shell">
+        <aside class="nav">
+            <h1>Mock Portal</h1>
+            <a href="./index.html">Overview</a>
+            <a href="./ai-studio-metadata.html">AI Studio metadata</a>
+        </aside>
+        <main class="main">
+            <section class="blade">
+                <h2>Azure AI Studio resource details</h2>
+            </section>
+
+            <section class="card">
+                <div class="form-row" role="row">
+                    <div class="label">Created by</div>
+                    <div class="value">developer@example.com</div>
+                    <span></span>
+                </div>
+                <div class="form-row" role="row">
+                    <div class="label">Modified by</div>
+                    <div class="value">streamer@contoso.dev</div>
+                    <span></span>
+                </div>
+                <div class="form-row" role="row">
+                    <div class="label">Endpoint uri</div>
+                    <a class="value" href="https://contoso-openai-eastus2.openai.azure.com/">https://contoso-openai-eastus2.openai.azure.com/</a>
+                    <button type="button">Copy</button>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/mock-portal/app.js
+++ b/mock-portal/app.js
@@ -1,0 +1,76 @@
+function toggleText(button, selector, hiddenValue, shownValue) {
+    const target = document.querySelector(selector);
+    if (!target) {
+        return;
+    }
+
+    const isHidden = button.dataset.state !== 'shown';
+    target.textContent = isHidden ? shownValue : hiddenValue;
+    button.dataset.state = isHidden ? 'shown' : 'hidden';
+    button.textContent = isHidden ? 'Hide' : 'Show';
+}
+
+function setupTooltipScenario() {
+    const button = document.querySelector('#tooltip-toggle');
+    const target = document.querySelector('#dynamic-tooltip-value');
+    if (!button || !target) {
+        return;
+    }
+
+    button.addEventListener('click', () => {
+        target.classList.toggle('expanded');
+        target.setAttribute('title', target.getAttribute('title') ? '' : 'cdn-origin-westus2.contoso.internal');
+    });
+}
+
+function setupDropdownScenario() {
+    const button = document.querySelector('#dropdown-button');
+    const menu = document.querySelector('#dropdown-menu');
+    if (!button || !menu) {
+        return;
+    }
+
+    button.addEventListener('mousedown', () => {
+        menu.hidden = false;
+        menu.setAttribute('aria-hidden', 'false');
+        button.setAttribute('aria-expanded', 'true');
+    });
+
+    button.addEventListener('click', () => {
+        const shouldHide = !menu.hidden;
+        menu.hidden = shouldHide;
+        menu.setAttribute('aria-hidden', shouldHide ? 'true' : 'false');
+        button.setAttribute('aria-expanded', shouldHide ? 'false' : 'true');
+    });
+}
+
+function setupStorageScenario() {
+    const keyButton = document.querySelector('#show-key1');
+    const sasButton = document.querySelector('#generate-sas');
+    if (keyButton) {
+        keyButton.addEventListener('click', () => {
+            toggleText(
+                keyButton,
+                '#key1-value',
+                '************************************',
+                'AbCdEfGhIjKlMnOpQrStUvWxYz1234567890KeyValue'
+            );
+        });
+    }
+
+    if (sasButton) {
+        sasButton.addEventListener('click', () => {
+            const target = document.querySelector('#sas-output');
+            if (!target) {
+                return;
+            }
+
+            target.textContent = 'sv=2024-08-04&ss=b&srt=sco&sp=rwdlacupiytfx&se=2030-07-01T12:00:00Z&sig=FakeSignatureValue1234567890';
+            target.className = 'output generated';
+        });
+    }
+}
+
+setupTooltipScenario();
+setupDropdownScenario();
+setupStorageScenario();

--- a/mock-portal/dropdown-tooltip.html
+++ b/mock-portal/dropdown-tooltip.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Dropdowns and Tooltips</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <div class="shell">
+        <aside class="nav">
+            <h1>Mock Portal</h1>
+            <a href="./index.html">Overview</a>
+            <a href="./dropdown-tooltip.html">Dropdowns and tooltips</a>
+        </aside>
+        <main class="main">
+            <section class="card">
+                <h2>CDN-style dropdown</h2>
+                <div class="dropdown">
+                    <button id="dropdown-button" type="button" aria-expanded="false">Origin name</button>
+                    <div id="dropdown-menu" class="menu" hidden aria-hidden="true">
+                        <div class="menu-item">cdn-origin-westus2.contoso.internal</div>
+                        <div class="menu-item">api-fallback-prod.eastus.cloudapp.azure.com</div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="card">
+                <h2>Dynamic tooltip update</h2>
+                <div id="dynamic-tooltip-value" class="value">Hover/inspect after toggling title updates</div>
+                <button id="tooltip-toggle" type="button">Toggle delayed tooltip</button>
+            </section>
+        </main>
+    </div>
+    <script src="./app.js"></script>
+</body>
+</html>

--- a/mock-portal/index.html
+++ b/mock-portal/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cloud Cloak Mock Portal</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <div class="shell">
+        <aside class="nav">
+            <h1>Mock Portal</h1>
+            <a href="./index.html">Overview</a>
+            <a href="./storage-access-keys.html">Storage access keys</a>
+            <a href="./ai-studio-metadata.html">AI Studio metadata</a>
+            <a href="./dropdown-tooltip.html">Dropdowns and tooltips</a>
+            <a href="./secure-fields.html">Secure fields</a>
+            <a href="./marker-contract.html">Marker contract</a>
+        </aside>
+        <main class="main">
+            <div class="command-bar">
+                <button type="button">Refresh</button>
+                <button type="button">Open in portal</button>
+            </div>
+
+            <section class="blade">
+                <h2>Cloud Cloak local test harness <span class="pill">dev only</span></h2>
+                <p class="hint">
+                    This site mimics Azure-style layouts and dynamic behaviors so you can validate masking locally without using real portal data.
+                </p>
+            </section>
+
+            <section class="card">
+                <h3>Available scenarios</h3>
+                <div class="row">
+                    <div class="label">Storage reveal flows</div>
+                    <div class="value">Show/Hide keys and Generate SAS output</div>
+                    <a class="button" href="./storage-access-keys.html">Open</a>
+                </div>
+                <div class="row">
+                    <div class="label">AI Studio metadata</div>
+                    <div class="value">Created by, Modified by, Endpoint URI</div>
+                    <a class="button" href="./ai-studio-metadata.html">Open</a>
+                </div>
+                <div class="row">
+                    <div class="label">Dropdown and tooltip timing</div>
+                    <div class="value">Menu flashes, delayed titles, hidden content</div>
+                    <a class="button" href="./dropdown-tooltip.html">Open</a>
+                </div>
+                <div class="row">
+                    <div class="label">Secure-like labeled fields</div>
+                    <div class="value">Passwords, tokens, client secrets, connection strings</div>
+                    <a class="button" href="./secure-fields.html">Open</a>
+                </div>
+                <div class="row">
+                    <div class="label">Explicit marker contract</div>
+                    <div class="value">data-cloudcloak opt-in examples</div>
+                    <a class="button" href="./marker-contract.html">Open</a>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/mock-portal/marker-contract.html
+++ b/mock-portal/marker-contract.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Marker Contract</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <div class="shell">
+        <aside class="nav">
+            <h1>Mock Portal</h1>
+            <a href="./index.html">Overview</a>
+            <a href="./marker-contract.html">Marker contract</a>
+        </aside>
+        <main class="main">
+            <section class="card">
+                <h2>Explicit opt-in markers</h2>
+                <div class="form-row">
+                    <div class="label">data-cloudcloak="cloak"</div>
+                    <div class="value" data-cloudcloak="cloak">team-specific-sensitive-value</div>
+                    <span></span>
+                </div>
+                <div class="form-row">
+                    <div class="label">data-cloudcloak="mask"</div>
+                    <div class="value" data-cloudcloak="mask">masked-by-contract@example.com</div>
+                    <span></span>
+                </div>
+                <div class="form-row">
+                    <div class="label">data-cloudcloak="sensitive"</div>
+                    <div class="value" data-cloudcloak="sensitive">https://internal-only.contoso.example/path</div>
+                    <span></span>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/mock-portal/secure-fields.html
+++ b/mock-portal/secure-fields.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Secure Fields</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <div class="shell">
+        <aside class="nav">
+            <h1>Mock Portal</h1>
+            <a href="./index.html">Overview</a>
+            <a href="./secure-fields.html">Secure fields</a>
+        </aside>
+        <main class="main">
+            <section class="card">
+                <div class="form-row">
+                    <label class="label">Password</label>
+                    <div class="textbox-like">correct-horse-battery-staple</div>
+                    <span></span>
+                </div>
+                <div class="form-row">
+                    <label class="label">Client Secret</label>
+                    <div class="textbox-like">plain-text-secret-value</div>
+                    <span></span>
+                </div>
+                <div class="form-row">
+                    <label class="label">Access token</label>
+                    <div class="textbox-like">token-value-that-does-not-look-like-a-guid</div>
+                    <span></span>
+                </div>
+                <div class="form-row">
+                    <label class="label">Connection string</label>
+                    <div class="textbox-like">Server=tcp:demo.database.windows.net;Database=streamdemo;User Id=demo;</div>
+                    <span></span>
+                </div>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/mock-portal/storage-access-keys.html
+++ b/mock-portal/storage-access-keys.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Storage Access Keys</title>
+    <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+    <div class="shell">
+        <aside class="nav">
+            <h1>Mock Portal</h1>
+            <a href="./index.html">Overview</a>
+            <a href="./storage-access-keys.html">Storage access keys</a>
+        </aside>
+        <main class="main">
+            <section class="blade">
+                <h2>Storage account access keys</h2>
+                <p class="hint">Exercise Show/Hide and Generate SAS flows.</p>
+            </section>
+
+            <section class="card">
+                <div class="form-row" role="row">
+                    <div class="label">Key 1</div>
+                    <div id="key1-value" class="value">************************************</div>
+                    <button id="show-key1" type="button">Show</button>
+                </div>
+                <div class="form-row" role="row">
+                    <div class="label">Connection string</div>
+                    <div class="value">DefaultEndpointsProtocol=https;AccountName=mockaccount;AccountKey=************************************;EndpointSuffix=core.windows.net</div>
+                    <button type="button">Copy</button>
+                </div>
+                <div class="form-row" role="row">
+                    <div class="label">Shared access signature</div>
+                    <div id="sas-output" class="output">No SAS generated yet</div>
+                    <button id="generate-sas" type="button">Generate SAS and connection string</button>
+                </div>
+            </section>
+        </main>
+    </div>
+    <script src="./app.js"></script>
+</body>
+</html>

--- a/mock-portal/styles.css
+++ b/mock-portal/styles.css
@@ -1,0 +1,142 @@
+body {
+    margin: 0;
+    font-family: "Segoe UI", Arial, sans-serif;
+    background: #0f172a;
+    color: #e2e8f0;
+}
+
+.shell {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    min-height: 100vh;
+}
+
+.nav {
+    background: #111827;
+    padding: 20px 16px;
+    border-right: 1px solid #1f2937;
+}
+
+.nav h1 {
+    font-size: 18px;
+    margin: 0 0 16px;
+}
+
+.nav a {
+    display: block;
+    color: #cbd5e1;
+    text-decoration: none;
+    padding: 8px 10px;
+    border-radius: 8px;
+    margin-bottom: 4px;
+}
+
+.nav a:hover {
+    background: #1e293b;
+}
+
+.main {
+    padding: 20px 28px 40px;
+}
+
+.command-bar {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+.command-bar button,
+.button {
+    background: #2563eb;
+    color: white;
+    border: 0;
+    border-radius: 8px;
+    padding: 8px 14px;
+    cursor: pointer;
+}
+
+.blade,
+.card {
+    background: #111827;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 16px;
+}
+
+.row,
+.form-row {
+    display: grid;
+    grid-template-columns: 220px 1fr auto;
+    gap: 12px;
+    align-items: center;
+    padding: 10px 0;
+    border-bottom: 1px solid #1f2937;
+}
+
+.row:last-child,
+.form-row:last-child {
+    border-bottom: 0;
+}
+
+.label {
+    color: #93c5fd;
+    font-weight: 600;
+}
+
+.value,
+.output,
+.content,
+.textbox-like {
+    background: #0b1220;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    padding: 8px 10px;
+    min-height: 20px;
+    word-break: break-all;
+}
+
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    min-width: 260px;
+    background: #0b1220;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    padding: 8px;
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+}
+
+.menu[hidden] {
+    display: none;
+}
+
+.menu-item {
+    display: block;
+    padding: 8px 10px;
+    border-radius: 6px;
+}
+
+.menu-item:hover {
+    background: #1e293b;
+}
+
+.hint {
+    color: #94a3b8;
+    font-size: 14px;
+}
+
+.pill {
+    display: inline-block;
+    border-radius: 999px;
+    padding: 2px 8px;
+    background: #1d4ed8;
+    font-size: 12px;
+    margin-left: 8px;
+}

--- a/package.json
+++ b/package.json
@@ -1,3 +1,8 @@
 {
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "dev:extension": "node scripts/build-dev-extension.mjs",
+    "dev:site": "node scripts/serve-mock-portal.mjs",
+    "test": "node --test tests/*.test.mjs"
+  }
 }

--- a/scripts/build-dev-extension.mjs
+++ b/scripts/build-dev-extension.mjs
@@ -1,0 +1,26 @@
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const manifestPath = resolve(repoRoot, 'manifest.json');
+const devManifestPath = resolve(repoRoot, 'dist', 'manifest.dev.json');
+
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+const localPatterns = [
+    'http://localhost:4173/*',
+    'http://127.0.0.1:4173/*'
+];
+
+manifest.host_permissions = [...manifest.host_permissions, ...localPatterns];
+manifest.web_accessible_resources = manifest.web_accessible_resources.map((resource) => ({
+    ...resource,
+    matches: [...resource.matches, ...localPatterns]
+}));
+
+await mkdir(resolve(repoRoot, 'dist'), { recursive: true });
+await writeFile(devManifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+await copyFile(devManifestPath, resolve(repoRoot, 'dist', 'manifest.json'));
+
+console.log(`Created dev manifest at ${devManifestPath}`);

--- a/scripts/serve-mock-portal.mjs
+++ b/scripts/serve-mock-portal.mjs
@@ -1,6 +1,6 @@
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
-import { extname, resolve } from 'node:path';
+import { extname, isAbsolute, normalize, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = resolve(fileURLToPath(new URL('..', import.meta.url)), 'mock-portal');
@@ -14,8 +14,20 @@ const mimeTypes = {
 
 createServer(async (req, res) => {
     try {
-        const requestPath = req.url === '/' ? '/index.html' : req.url.split('?')[0];
-        const filePath = resolve(root, `.${requestPath}`);
+        const requestUrl = new URL(req.url || '/', 'http://localhost');
+        const rawPathname = requestUrl.pathname === '/' ? '/index.html' : requestUrl.pathname;
+        const decodedPathname = decodeURIComponent(rawPathname);
+        const normalizedPath = normalize(decodedPathname).replace(/^[/\\]+/, '');
+        const relativePath = normalizedPath || 'index.html';
+        const filePath = resolve(root, relativePath);
+        const relativeToRoot = relative(root, filePath);
+
+        if (relativeToRoot.startsWith('..') || isAbsolute(relativeToRoot)) {
+            res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+            res.end('Forbidden');
+            return;
+        }
+
         const content = await readFile(filePath);
         res.writeHead(200, { 'Content-Type': mimeTypes[extname(filePath)] || 'text/plain; charset=utf-8' });
         res.end(content);

--- a/scripts/serve-mock-portal.mjs
+++ b/scripts/serve-mock-portal.mjs
@@ -1,0 +1,28 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { extname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(new URL('..', import.meta.url)), 'mock-portal');
+const port = 4173;
+
+const mimeTypes = {
+    '.html': 'text/html; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8'
+};
+
+createServer(async (req, res) => {
+    try {
+        const requestPath = req.url === '/' ? '/index.html' : req.url.split('?')[0];
+        const filePath = resolve(root, `.${requestPath}`);
+        const content = await readFile(filePath);
+        res.writeHead(200, { 'Content-Type': mimeTypes[extname(filePath)] || 'text/plain; charset=utf-8' });
+        res.end(content);
+    } catch {
+        res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+        res.end('Not found');
+    }
+}).listen(port, () => {
+    console.log(`Mock portal available at http://localhost:${port}`);
+});

--- a/tests/githubStaffBar.test.mjs
+++ b/tests/githubStaffBar.test.mjs
@@ -1,9 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { shouldHideGitHubStaffBar } from '../common.js';
+import { isGitHubUrl, shouldHideGitHubStaffBar } from '../common.js';
 
 test('targets staff bar removal on github.com and github.com subdomains', () => {
+    assert.equal(isGitHubUrl('https://github.com/microsoft/cloudcloak/pull/82'), true);
+    assert.equal(isGitHubUrl('https://gist.github.com/microsoft'), true);
+    assert.equal(isGitHubUrl('https://docs.github.com/en'), true);
+    assert.equal(isGitHubUrl('https://raw.githubusercontent.com/microsoft/cloudcloak/main/README.md'), false);
+    assert.equal(isGitHubUrl('http://github.com/microsoft/cloudcloak'), false);
+    assert.equal(isGitHubUrl('https://notgithub.com/microsoft'), false);
+    assert.equal(isGitHubUrl(''), false);
+
     assert.equal(shouldHideGitHubStaffBar('https://github.com/microsoft/cloudcloak/pull/82'), true);
     assert.equal(shouldHideGitHubStaffBar('https://github.com/'), true);
     assert.equal(shouldHideGitHubStaffBar('https://gist.github.com/microsoft'), true);

--- a/tests/githubStaffBar.test.mjs
+++ b/tests/githubStaffBar.test.mjs
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldHideGitHubStaffBar } from '../common.js';
+
+test('targets staff bar removal on github.com and github.com subdomains', () => {
+    assert.equal(shouldHideGitHubStaffBar('https://github.com/microsoft/cloudcloak/pull/82'), true);
+    assert.equal(shouldHideGitHubStaffBar('https://github.com/'), true);
+    assert.equal(shouldHideGitHubStaffBar('https://gist.github.com/microsoft'), true);
+    assert.equal(shouldHideGitHubStaffBar('https://docs.github.com/en'), true);
+    assert.equal(shouldHideGitHubStaffBar('http://github.com/microsoft/cloudcloak'), false);
+    assert.equal(shouldHideGitHubStaffBar('https://notgithub.com/microsoft'), false);
+});

--- a/tests/githubStaffBar.test.mjs
+++ b/tests/githubStaffBar.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isGitHubUrl, shouldHideGitHubStaffBar } from '../common.js';
+import { isGitHubSettingsUrl, isGitHubUrl, shouldHideGitHubStaffBar } from '../common.js';
 
 test('targets staff bar removal on github.com and github.com subdomains', () => {
     assert.equal(isGitHubUrl('https://github.com/microsoft/cloudcloak/pull/82'), true);
@@ -11,6 +11,12 @@ test('targets staff bar removal on github.com and github.com subdomains', () => 
     assert.equal(isGitHubUrl('http://github.com/microsoft/cloudcloak'), false);
     assert.equal(isGitHubUrl('https://notgithub.com/microsoft'), false);
     assert.equal(isGitHubUrl(''), false);
+    assert.equal(isGitHubSettingsUrl('https://github.com/settings/profile'), true);
+    assert.equal(isGitHubSettingsUrl('https://github.com/orgs/microsoft/settings/profile'), true);
+    assert.equal(isGitHubSettingsUrl('https://github.com/microsoft/cloudcloak/settings/secrets/actions'), true);
+    assert.equal(isGitHubSettingsUrl('https://github.com/microsoft/cloudcloak/blob/main/README.md'), false);
+    assert.equal(isGitHubSettingsUrl('https://docs.github.com/en'), false);
+    assert.equal(isGitHubSettingsUrl('https://gist.github.com/microsoft'), false);
 
     assert.equal(shouldHideGitHubStaffBar('https://github.com/microsoft/cloudcloak/pull/82'), true);
     assert.equal(shouldHideGitHubStaffBar('https://github.com/'), true);

--- a/tests/hostPermissions.test.mjs
+++ b/tests/hostPermissions.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import {
+    supportedDomains,
+    supportedHostPermissionPatterns
+} from '../common.js';
+
+const manifest = JSON.parse(
+    await readFile(new URL('../manifest.json', import.meta.url), 'utf8')
+);
+
+function matchesHostPermission(url, pattern) {
+    const candidateUrl = new URL(url);
+    const [scheme, hostAndPath] = pattern.split('://');
+    const matchHostname = hostAndPath.slice(0, -2);
+
+    if (candidateUrl.protocol !== `${scheme}:`) {
+        return false;
+    }
+
+    const candidateHostname = candidateUrl.hostname;
+    if (!matchHostname.startsWith('*.')) {
+        return candidateHostname === matchHostname;
+    }
+
+    const hostnameSuffix = matchHostname.slice(2);
+    return candidateHostname.endsWith(`.${hostnameSuffix}`);
+}
+
+function getRepresentativeSupportedUrl(supportedDomain) {
+    return supportedDomain
+        .replace('reactblade-ms*', 'reactblade-ms123')
+        .replace('reactblade*', 'reactblade123')
+        .replace('https://*.reactblade-ms.portal.azure.net', 'https://child.reactblade-ms.portal.azure.net')
+        .replace('https://*.reactblade.portal.azure.net', 'https://child.reactblade.portal.azure.net');
+}
+
+test('manifest host permissions stay aligned with supported host permission patterns', () => {
+    assert.deepEqual(manifest.host_permissions, supportedHostPermissionPatterns);
+    assert.deepEqual(manifest.web_accessible_resources[0]?.matches, supportedHostPermissionPatterns);
+});
+
+test('supported host permission patterns cover supported domains', () => {
+    const uncoveredSupportedUrls = supportedDomains
+        .map(getRepresentativeSupportedUrl)
+        .filter((supportedUrl) => !supportedHostPermissionPatterns.some((pattern) => matchesHostPermission(supportedUrl, pattern)));
+
+    assert.deepEqual(uncoveredSupportedUrls, []);
+});

--- a/tests/hostPermissions.test.mjs
+++ b/tests/hostPermissions.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import {
+    localTestHostPermissionPatterns,
     supportedDomains,
     supportedHostPermissionPatterns
 } from '../common.js';
@@ -48,4 +49,15 @@ test('supported host permission patterns cover supported domains', () => {
         .filter((supportedUrl) => !supportedHostPermissionPatterns.some((pattern) => matchesHostPermission(supportedUrl, pattern)));
 
     assert.deepEqual(uncoveredSupportedUrls, []);
+});
+
+test('local test host permissions stay out of the production allowlist', () => {
+    assert.deepEqual(localTestHostPermissionPatterns, [
+        'http://localhost:4173/*',
+        'http://127.0.0.1:4173/*'
+    ]);
+    assert.equal(
+        supportedHostPermissionPatterns.some((pattern) => pattern.includes('localhost') || pattern.includes('127.0.0.1')),
+        false
+    );
 });

--- a/tests/hostPermissions.test.mjs
+++ b/tests/hostPermissions.test.mjs
@@ -34,6 +34,7 @@ function getRepresentativeSupportedUrl(supportedDomain) {
     return supportedDomain
         .replace('reactblade-ms*', 'reactblade-ms123')
         .replace('reactblade*', 'reactblade123')
+        .replace('https://*.github.com', 'https://gist.github.com')
         .replace('https://*.reactblade-ms.portal.azure.net', 'https://child.reactblade-ms.portal.azure.net')
         .replace('https://*.reactblade.portal.azure.net', 'https://child.reactblade.portal.azure.net');
 }

--- a/tests/observerConfig.test.mjs
+++ b/tests/observerConfig.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { cloakObserverOptions } from '../common.js';
+
+test('observes title attribute mutations for tooltip masking', () => {
+    assert.equal(cloakObserverOptions.attributes, true);
+    assert.deepEqual(cloakObserverOptions.attributeFilter, ['title']);
+    assert.equal(cloakObserverOptions.childList, true);
+    assert.equal(cloakObserverOptions.subtree, true);
+    assert.equal(cloakObserverOptions.characterData, true);
+});

--- a/tests/observerConfig.test.mjs
+++ b/tests/observerConfig.test.mjs
@@ -3,9 +3,12 @@ import assert from 'node:assert/strict';
 
 import { cloakObserverOptions } from '../common.js';
 
-test('observes title attribute mutations for tooltip masking', () => {
+test('observes title and visibility-related attribute mutations for dynamic masking', () => {
     assert.equal(cloakObserverOptions.attributes, true);
-    assert.deepEqual(cloakObserverOptions.attributeFilter, ['title']);
+    assert.deepEqual(
+        cloakObserverOptions.attributeFilter,
+        ['title', 'class', 'style', 'hidden', 'aria-expanded', 'aria-hidden']
+    );
     assert.equal(cloakObserverOptions.childList, true);
     assert.equal(cloakObserverOptions.subtree, true);
     assert.equal(cloakObserverOptions.characterData, true);

--- a/tests/observerConfig.test.mjs
+++ b/tests/observerConfig.test.mjs
@@ -7,7 +7,7 @@ test('observes title and visibility-related attribute mutations for dynamic mask
     assert.equal(cloakObserverOptions.attributes, true);
     assert.deepEqual(
         cloakObserverOptions.attributeFilter,
-        ['title', 'class', 'style', 'hidden', 'aria-expanded', 'aria-hidden']
+        ['title', 'class', 'style', 'hidden', 'aria-expanded', 'aria-hidden', 'data-cloudcloak']
     );
     assert.equal(cloakObserverOptions.childList, true);
     assert.equal(cloakObserverOptions.subtree, true);

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -44,6 +44,13 @@ test('matches Azure Storage access key routes', () => {
     );
 });
 
+test('Azure Storage access key rule targets reveal-flow containers and output-like elements', () => {
+    assert.equal(azureStorageAccessKeyRule.maskClosestSelector.includes("[role='row']"), true);
+    assert.equal(azureStorageAccessKeyRule.valueSelectors.includes("[class*='output']"), true);
+    assert.equal(azureStorageAccessKeyRule.valueSelectors.includes("code"), true);
+    assert.equal(azureStorageAccessKeyRule.valueSelectors.includes("pre"), true);
+});
+
 test('matches Azure AI Studio key routes', () => {
     assert.equal(
         matchesPageRuleUrl(

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -69,6 +69,16 @@ test('matches Azure AI Studio key routes', () => {
     );
 });
 
+test('Azure AI Studio rule covers metadata fields and output-like containers', () => {
+    assert.equal(azureAiStudioKeysRule.contextLabels.includes('created by'), true);
+    assert.equal(azureAiStudioKeysRule.contextLabels.includes('modified by'), true);
+    assert.equal(azureAiStudioKeysRule.contextLabels.includes('endpoint uri'), true);
+    assert.equal(azureAiStudioKeysRule.valueSelectors.includes('[class*="output"]'), false);
+    assert.equal(azureAiStudioKeysRule.valueSelectors.includes("[class*='output']"), true);
+    assert.equal(azureAiStudioKeysRule.valueSelectors.includes('a[href]'), true);
+    assert.equal(azureAiStudioKeysRule.maskClosestSelector.includes("[role='row']"), true);
+});
+
 test('does not match unrelated Azure Storage routes', () => {
     assert.equal(
         matchesPageRuleUrl(

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -21,6 +21,8 @@ test('normalizes page rule text for label matching', () => {
 test('matches page rule labels on word boundaries instead of substrings', () => {
     assert.equal(matchesPageRuleLabel('key', 'Storage account key'), true);
     assert.equal(matchesPageRuleLabel('connection string', 'Primary connection string'), true);
+    assert.equal(matchesPageRuleLabel('client secret', 'Client Secret value'), true);
+    assert.equal(matchesPageRuleLabel('token', 'Access token'), true);
     assert.equal(matchesPageRuleLabel('key', 'Search keywords'), false);
     assert.equal(matchesPageRuleLabel('key', 'Keyboard shortcut'), false);
     assert.equal(matchesPageRuleLabel('key 1', 'Key 1'), true);

--- a/tests/pageSpecificRules.test.mjs
+++ b/tests/pageSpecificRules.test.mjs
@@ -75,8 +75,10 @@ test('Azure AI Studio rule covers metadata fields and output-like containers', (
     assert.equal(azureAiStudioKeysRule.contextLabels.includes('created by'), true);
     assert.equal(azureAiStudioKeysRule.contextLabels.includes('modified by'), true);
     assert.equal(azureAiStudioKeysRule.contextLabels.includes('endpoint uri'), true);
-    assert.equal(azureAiStudioKeysRule.valueSelectors.includes('[class*="output"]'), false);
-    assert.equal(azureAiStudioKeysRule.valueSelectors.includes("[class*='output']"), true);
+    const hasOutputClassSelector = azureAiStudioKeysRule.valueSelectors.some((selector) =>
+        /\[class\*=['"]output['"]\]/.test(selector)
+    );
+    assert.equal(hasOutputClassSelector, true);
     assert.equal(azureAiStudioKeysRule.valueSelectors.includes('a[href]'), true);
     assert.equal(azureAiStudioKeysRule.maskClosestSelector.includes("[role='row']"), true);
 });


### PR DESCRIPTION
## Summary
- tighten manifest host permissions and align frame injection with the supported portal allowlist (#32)
- observe dynamic tooltip and visibility mutations to reduce tooltip and dropdown flashes (#38, #44)
- harden Azure Storage and AI Studio page-aware masking for reveal flows and metadata fields (#45, #47)
- broaden label-aware masking for secret-like fields that do not match existing regexes (#22)
- add explicit `data-cloudcloak` opt-in markers for product teams that want guaranteed masking (#19)

## Included issue fixes
Closes #19
Closes #22
Closes #32
Closes #38
Closes #44
Closes #45
Closes #47